### PR TITLE
Update Dockerfile due to not being able to find curl on docker machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ ENV BODY_SIZE_LIMIT=512M
 
 ENV POCKETBASE_VERSION=0.22.21
 # Install required packages
-RUN apk update && apk add --no-cache wget ffmpeg unzip libgd libmad libid3tag boost-static boost-build
+RUN apk update && apk add --no-cache wget ffmpeg unzip libgd libmad libid3tag boost-static boost-build curl
 
 COPY --from=build_flac /usr/local/bin/* /usr/local/bin/
 COPY --from=build_flac /usr/local/share/man/man1/* /usr/local/share/man/man1/


### PR DESCRIPTION
Basically if you dont explicitly install curl on the docker machine, you run into the issue of the download of pocketbase failing due to the machine being unable to locate curl. I'm running this on a windows PC so I believe the type of issues comes from alpine on windows not coming pre installed with curl compared to a mac system which does. Might as well include it anyway as it doesnt hurt downloading the same file. 