### PR TITLE
Update GitHub Actions workflow for Docker image builds

### DIFF
--- a/.github/workflows/build-images-main.yml
+++ b/.github/workflows/build-images-main.yml
@@ -1,0 +1,52 @@
+name: build-images-main
+
+on:
+  push:
+    branches:
+      - main  # Only trigger on pushes to the main branch
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push scriberr:main Docker image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: ./Dockerfile
+          tags: |
+            ghcr.io/rishikanthc/scriberr:main
+
+      - name: Build and push scriberr:main-gpu Docker image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: ./Dockerfile-gpu
+          tags: |
+            ghcr.io/rishikanthc/scriberr:main-gpu
+
+      - name: Verify multi-platform image for scriberr:main
+        run: |
+          docker buildx imagetools inspect ghcr.io/rishikanthc/scriberr:latest
+
+      - name: Verify multi-platform image for scriberr:main-gpu
+        run: |
+          docker buildx imagetools inspect ghcr.io/rishikanthc/scriberr:latest-gpu

--- a/.github/workflows/build-images-nightly.yml
+++ b/.github/workflows/build-images-nightly.yml
@@ -1,7 +1,9 @@
-name: ci
+name: build-images-nightly
 
 on:
   push:
+    branches:
+      - nightly  # Only trigger on pushes to the nightly branch
 
 jobs:
   docker:
@@ -9,13 +11,13 @@ jobs:
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
-        
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -23,21 +25,28 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push scriberr:nightly Docker image
         uses: docker/build-push-action@v6
-        with:  
+        with:
           platforms: linux/amd64,linux/arm64
           push: true
           file: ./Dockerfile
           tags: |
             ghcr.io/rishikanthc/scriberr:nightly
 
-      - name: Verify multi-platform image
+      - name: Build and push scriberr:nightly-gpu Docker image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: ./Dockerfile-gpu
+          tags: |
+            ghcr.io/rishikanthc/scriberr:nightly-gpu
+
+      - name: Verify multi-platform image for scriberr:nightly
         run: |
           docker buildx imagetools inspect ghcr.io/rishikanthc/scriberr:nightly
 
-      - name: Push image to GHCR
+      - name: Verify multi-platform image for scriberr:nightly-gpu
         run: |
-          docker buildx imagetools create \
-            ghcr.io/rishikanthc/scriberr:nightly \
-            --tag ghcr.io/rishikanthc/scriberr:nightly
+          docker buildx imagetools inspect ghcr.io/rishikanthc/scriberr:nightly-gpu


### PR DESCRIPTION
- Change workflow name to 'build-images-main' for better clarity
- Limit workflow to trigger only on pushes to the 'main' branch
- Add steps to build and push a new GPU-enabled Docker image (scriberr:main-gpu) alongside the existing main image
- Create workflow "build-images-nightly.yml" to allow for images that are still in testing to be built when pushed to the Nightly branch. It is limited to the Nightly branch.
- Nightly branch will build a GPU and CPU only version.
- Ensure each image is verified for multi-platform support after the build process