### PR TITLE
fix: Add fallback from float16 to float32 for GPUs without efficient float16 support

### DIFF
--- a/src/lib/server/transcription.ts
+++ b/src/lib/server/transcription.ts
@@ -198,8 +198,19 @@ export const transcribeAudio = async (fileId: number, transcribeStream: any) => 
     args.push('--device', device);
     
     // Compute type based on device
+    // For CUDA devices, try float16 by default but the Python script has fallback to float32
+    // For CPU devices, use int8 which is more efficient
     const computeType = device === 'cuda' ? 'float16' : 'int8';
-    args.push('--compute-type', computeType);
+    
+    // Check if WHISPER_COMPUTE_TYPE environment variable is set to override the default
+    const envComputeType = process.env.WHISPER_COMPUTE_TYPE;
+    if (envComputeType) {
+      console.log(`Using compute type from environment: ${envComputeType}`);
+      args.push('--compute-type', envComputeType);
+    } else {
+      console.log(`Using default compute type: ${computeType}`);
+      args.push('--compute-type', computeType);
+    }
     
     console.log('Executing Python with args:', args);
     

--- a/transcribe.py
+++ b/transcribe.py
@@ -89,14 +89,29 @@ def main():
     )
     args = parser.parse_args()
 
-    # 1. Load the WhisperX model
-    model = whisperx.load_model(
-        args.model_size,
-        device=args.device,
-        compute_type=args.compute_type,
-        language=args.language,  # if None, Whisper will attempt language detection
-        download_root=args.models_dir  # Specify the download directory
-    )
+    # 1. Load the WhisperX model with fallback for compute_type
+    try:
+        model = whisperx.load_model(
+            args.model_size,
+            device=args.device,
+            compute_type=args.compute_type,
+            language=args.language,  # if None, Whisper will attempt language detection
+            download_root=args.models_dir  # Specify the download directory
+        )
+    except ValueError as e:
+        if "float16 compute type" in str(e) and args.compute_type == "float16":
+            print(f"Warning: {e}")
+            print("Trying with float32 compute type instead...")
+            model = whisperx.load_model(
+                args.model_size,
+                device=args.device,
+                compute_type="float32",
+                language=args.language,
+                download_root=args.models_dir
+            )
+        else:
+            # Re-raise if it's not the float16 issue or fallback also fails
+            raise
 
     # 2. Load audio
     audio = whisperx.load_audio(args.audio_file)


### PR DESCRIPTION
## Summary
- Add automatic fallback from float16 to float32 compute precision when GPU doesn't support efficient float16 operations
- Add WHISPER_COMPUTE_TYPE environment variable support to allow manual compute type configuration
- Improve logging for compute type selection

## Test plan
- Test on GPU that supports float16 (should continue using float16)
- Test on GPU that doesn't support efficient float16 (should fallback to float32 automatically)
- Test using WHISPER_COMPUTE_TYPE environment variable to explicitly set compute type

🤖 Generated with [Claude Code](https://claude.ai/code)