### PR TITLE
feat: Add i18n support and initial Chinese translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"postgres": "",
 				"speech-recognition": "",
 				"svelte-file-dropzone": "",
+				"svelte-i18n": "4.0.1",
 				"wavesurfer.js": ""
 			},
 			"devDependencies": {
@@ -635,7 +636,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -652,7 +652,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -669,7 +668,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -686,7 +684,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -703,7 +700,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -720,7 +716,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -737,7 +732,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -754,7 +748,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -771,7 +764,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -788,7 +780,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -805,7 +796,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -822,7 +812,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -839,7 +828,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -856,7 +844,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -873,7 +860,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -890,7 +876,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -907,7 +892,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -940,7 +924,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -973,7 +956,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -990,7 +972,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1007,7 +988,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1024,7 +1004,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1041,7 +1020,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1219,6 +1197,57 @@
 			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@formatjs/ecma402-abstract": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+			"integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@formatjs/fast-memoize": "2.2.7",
+				"@formatjs/intl-localematcher": "0.6.1",
+				"decimal.js": "^10.4.3",
+				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@formatjs/fast-memoize": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+			"integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@formatjs/icu-messageformat-parser": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+			"integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+			"license": "MIT",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "2.3.4",
+				"@formatjs/icu-skeleton-parser": "1.8.14",
+				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@formatjs/icu-skeleton-parser": {
+			"version": "1.8.14",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+			"integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "2.3.4",
+				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@formatjs/intl-localematcher": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+			"integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.0"
+			}
 		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
@@ -3175,6 +3204,22 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/cli-color": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
+			"integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.64",
+				"es6-iterator": "^2.0.3",
+				"memoizee": "^0.4.15",
+				"timers-ext": "^0.1.7"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3283,6 +3328,19 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/d": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+			"integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+			"license": "ISC",
+			"dependencies": {
+				"es5-ext": "^0.10.64",
+				"type": "^2.7.2"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -3299,6 +3357,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"license": "MIT"
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -3609,11 +3673,62 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es5-ext": {
+			"version": "0.10.64",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+			"hasInstallScript": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"license": "MIT",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"node_modules/es6-symbol": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+			"integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "^1.0.2",
+				"ext": "^1.7.0"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/es6-weak-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.1"
+			}
+		},
 		"node_modules/esbuild": {
 			"version": "0.19.12",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
 			"integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -3858,6 +3973,21 @@
 			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
 			"license": "MIT"
 		},
+		"node_modules/esniff": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.62",
+				"event-emitter": "^0.3.5",
+				"type": "^2.7.2"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/espree": {
 			"version": "10.3.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
@@ -3937,6 +4067,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"license": "MIT",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
 		"node_modules/event-target-shim": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -3944,6 +4084,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/ext": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+			"license": "ISC",
+			"dependencies": {
+				"type": "^2.7.2"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -4370,6 +4519,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globalyzer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+			"license": "MIT"
+		},
+		"node_modules/globrex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+			"license": "MIT"
+		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4522,6 +4683,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/intl-messageformat": {
+			"version": "10.7.16",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+			"integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "2.3.4",
+				"@formatjs/fast-memoize": "2.2.7",
+				"@formatjs/icu-messageformat-parser": "2.11.2",
+				"tslib": "^2.8.0"
+			}
+		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4608,6 +4781,12 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
+		},
+		"node_modules/is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-reference": {
 			"version": "1.2.1",
@@ -5039,6 +5218,15 @@
 				"node": "20 || >=22"
 			}
 		},
+		"node_modules/lru-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+			"integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es5-ext": "~0.10.2"
+			}
+		},
 		"node_modules/lucide-svelte": {
 			"version": "0.475.0",
 			"resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.475.0.tgz",
@@ -5086,6 +5274,25 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/memoizee": {
+			"version": "0.4.17",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+			"integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "^1.0.2",
+				"es5-ext": "^0.10.64",
+				"es6-weak-map": "^2.0.3",
+				"event-emitter": "^0.3.5",
+				"is-promise": "^2.2.2",
+				"lru-queue": "^0.1.0",
+				"next-tick": "^1.1.0",
+				"timers-ext": "^0.1.7"
+			},
+			"engines": {
+				"node": ">=0.12"
 			}
 		},
 		"node_modules/merge2": {
@@ -5305,6 +5512,12 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/next-tick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+			"license": "ISC"
 		},
 		"node_modules/node-domexception": {
 			"version": "1.0.0",
@@ -6873,6 +7086,30 @@
 				"svelte": "^3.54.0 || ^4.0.0 || ^5"
 			}
 		},
+		"node_modules/svelte-i18n": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/svelte-i18n/-/svelte-i18n-4.0.1.tgz",
+			"integrity": "sha512-jaykGlGT5PUaaq04JWbJREvivlCnALtT+m87Kbm0fxyYHynkQaxQMnIKHLm2WeIuBRoljzwgyvz0Z6/CMwfdmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cli-color": "^2.0.3",
+				"deepmerge": "^4.2.2",
+				"esbuild": "^0.19.2",
+				"estree-walker": "^2",
+				"intl-messageformat": "^10.5.3",
+				"sade": "^1.8.1",
+				"tiny-glob": "^0.2.9"
+			},
+			"bin": {
+				"svelte-i18n": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"peerDependencies": {
+				"svelte": "^3 || ^4 || ^5"
+			}
+		},
 		"node_modules/svelte-sonner": {
 			"version": "0.3.28",
 			"resolved": "https://registry.npmjs.org/svelte-sonner/-/svelte-sonner-0.3.28.tgz",
@@ -7200,6 +7437,29 @@
 				"readable-stream": "3"
 			}
 		},
+		"node_modules/timers-ext": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+			"integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+			"license": "ISC",
+			"dependencies": {
+				"es5-ext": "^0.10.64",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/tiny-glob": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+			"license": "MIT",
+			"dependencies": {
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7260,6 +7520,12 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
+		},
+		"node_modules/type": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+			"integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+			"license": "ISC"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"postgres": "",
 		"speech-recognition": "",
 		"svelte-file-dropzone": "",
-		"wavesurfer.js": ""
+		"wavesurfer.js": "",
+		"svelte-i18n": "4.0.1"
 	}
 }

--- a/src/lib/components/LanguageSwitcher.svelte
+++ b/src/lib/components/LanguageSwitcher.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { locale } from 'svelte-i18n';
+  import { browser } from '$app/environment';
+
+  const locales = {
+    'en': 'English',
+    'zh-TW': '繁體中文'
+  };
+
+  function handleChange(event: Event) {
+    const newLocale = (event.target as HTMLSelectElement).value;
+    if (newLocale) {
+      locale.set(newLocale);
+      if (browser) {
+        localStorage.setItem('selectedLocale', newLocale);
+      }
+    }
+  }
+
+  // Set the initial value of the select dropdown from localStorage if available
+  let selectedLocale = 'en';
+  if (browser) {
+    selectedLocale = localStorage.getItem('selectedLocale') || $locale || 'en';
+  }
+</script>
+
+<div class="language-switcher">
+  <select bind:value={selectedLocale} on:change={handleChange} aria-label="Language selector">
+    {#each Object.entries(locales) as [value, name]}
+      <option {value}>{name}</option>
+    {/each}
+  </select>
+</div>
+
+<style>
+  .language-switcher {
+    position: relative;
+    display: inline-block;
+  }
+  select {
+    padding: 8px 12px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background-color: white;
+    cursor: pointer;
+  }
+</style>

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,0 +1,19 @@
+import { browser } from '$app/environment'
+import { init, register } from 'svelte-i18n'
+
+const defaultLocale = 'en'
+
+// Register the locales
+register('en', () => import('./locales/en.json'))
+register('zh-TW', () => import('./locales/zh-TW.json'))
+
+// Determine initial locale
+let initialLocale = defaultLocale;
+if (browser) {
+  initialLocale = localStorage.getItem('selectedLocale') || window.navigator.language || defaultLocale;
+}
+
+init({
+  fallbackLocale: defaultLocale,
+  initialLocale: initialLocale,
+})

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1,0 +1,103 @@
+{
+  "test": {
+    "greeting": "Hello, World!"
+  },
+  "home": {
+    "nav": {
+      "record": "Record",
+      "files": "Files",
+      "upload": "Upload",
+      "status": "Status",
+      "templates": "Templates",
+      "account": "Account"
+    },
+    "nav_aria": {
+      "record": "Record Audio",
+      "files": "Files",
+      "upload": "Upload Files",
+      "status": "Processing Status",
+      "templates": "Templates",
+      "account": "User Menu"
+    },
+    "account_menu": {
+      "my_account": "My Account",
+      "logout": "Log out"
+    },
+    "files": {
+      "back": "Back to Files",
+      "select_prompt": "Select a recording from the list to view details"
+    }
+  },
+  "upload_panel": {
+    "title": "Upload Audio",
+    "status": {
+      "uploading": "Uploading...",
+      "success": "Upload complete",
+      "failed": "Upload failed"
+    },
+    "dropzone": {
+      "prompt": "Drop audio files here",
+      "prompt_alt": "or click to select files"
+    }
+  },
+  "settings_panel": {
+    "model_size": {
+      "label": "Model Size",
+      "tiny": "Tiny (Fast)",
+      "base": "Base (Balanced)",
+      "small": "Small (Better)",
+      "medium": "Medium (Good)",
+      "large": "Large (Best)",
+      "large_v2": "Large v2 (Enhanced)",
+      "large_v3": "Large v3 (Latest)"
+    },
+    "language": {
+      "label": "Language",
+      "auto_detect": "Auto Detect"
+    },
+    "cpu_threads": {
+      "label": "CPU Threads",
+      "suffix": "Threads"
+    },
+    "cpu_processors": {
+      "label": "CPU Processors",
+      "suffix": "Processors"
+    },
+    "speaker_detection": {
+      "label": "Speaker Detection",
+      "enable": "Enable speaker identification",
+      "note_title": "Note:",
+      "note_body": "Speaker detection requires a HuggingFace API token with access to `pyannote` models. Make sure to add your token to the `HUGGINGFACE_TOKEN` environment variable in your `.env` file."
+    }
+  },
+  "status_panel": {
+    "title": "Active Transcription Jobs",
+    "progress": {
+      "analyzing": "analyzing",
+      "transcribed": "transcribed"
+    },
+    "errors": {
+      "connection_lost": "Lost connection to server"
+    },
+    "no_active_jobs": "No active transcription jobs"
+  },
+  "templates_list": {
+    "title": "Summary Templates",
+    "new_button": "New",
+    "new_dialog": {
+      "title": "New Template"
+    },
+    "edit_dialog": {
+      "title": "Edit Template"
+    },
+    "form": {
+      "title_placeholder": "Template Title",
+      "prompt_placeholder": "Summarization Prompt",
+      "save_button": "Save Template",
+      "update_button": "Update Template"
+    },
+    "toasts": {
+      "created": "Template created"
+    }
+  }
+}

--- a/src/lib/i18n/locales/zh-TW.json
+++ b/src/lib/i18n/locales/zh-TW.json
@@ -1,0 +1,103 @@
+{
+  "test": {
+    "greeting": "哈囉，世界！"
+  },
+  "home": {
+    "nav": {
+      "record": "錄音",
+      "files": "檔案",
+      "upload": "上傳",
+      "status": "狀態",
+      "templates": "範本",
+      "account": "帳戶"
+    },
+    "nav_aria": {
+      "record": "錄製音訊",
+      "files": "檔案",
+      "upload": "上傳檔案",
+      "status": "處理狀態",
+      "templates": "範本",
+      "account": "使用者選單"
+    },
+    "account_menu": {
+      "my_account": "我的帳戶",
+      "logout": "登出"
+    },
+    "files": {
+      "back": "回到檔案列表",
+      "select_prompt": "從列表中選擇一個錄音以查看詳細資訊"
+    }
+  },
+  "upload_panel": {
+    "title": "上傳音訊",
+    "status": {
+      "uploading": "上傳中...",
+      "success": "上傳成功",
+      "failed": "上傳失敗"
+    },
+    "dropzone": {
+      "prompt": "將音訊檔案拖放到此處",
+      "prompt_alt": "或點擊以選擇檔案"
+    }
+  },
+  "settings_panel": {
+    "model_size": {
+      "label": "模型大小",
+      "tiny": "微型 (最快)",
+      "base": "基礎 (平衡)",
+      "small": "小型 (較佳)",
+      "medium": "中型 (良好)",
+      "large": "大型 (最佳)",
+      "large_v2": "大型 v2 (增強)",
+      "large_v3": "大型 v3 (最新)"
+    },
+    "language": {
+      "label": "語言",
+      "auto_detect": "自動偵測"
+    },
+    "cpu_threads": {
+      "label": "CPU 執行緒",
+      "suffix": "執行緒"
+    },
+    "cpu_processors": {
+      "label": "CPU 處理器",
+      "suffix": "處理器"
+    },
+    "speaker_detection": {
+      "label": "說話者偵測",
+      "enable": "啟用說話者識別",
+      "note_title": "注意：",
+      "note_body": "說話者偵測需要一個有權存取 `pyannote` 模型的 HuggingFace API 金鑰。請確保您已將金鑰新增至 `.env` 檔案中的 `HUGGINGFACE_TOKEN` 環境變數。"
+    }
+  },
+  "status_panel": {
+    "title": "進行中的轉錄工作",
+    "progress": {
+      "analyzing": "分析中",
+      "transcribed": "轉錄完成"
+    },
+    "errors": {
+      "connection_lost": "與伺服器連線中斷"
+    },
+    "no_active_jobs": "沒有進行中的轉錄工作"
+  },
+  "templates_list": {
+    "title": "摘要範本",
+    "new_button": "新增",
+    "new_dialog": {
+      "title": "新增範本"
+    },
+    "edit_dialog": {
+      "title": "編輯範本"
+    },
+    "form": {
+      "title_placeholder": "範本標題",
+      "prompt_placeholder": "摘要提示",
+      "save_button": "儲存範本",
+      "update_button": "更新範本"
+    },
+    "toasts": {
+      "created": "範本已建立"
+    }
+  }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import ConfigWizard from './ConfigWizard.svelte';
+	import LanguageSwitcher from '$lib/components/LanguageSwitcher.svelte';
 	import { browser } from '$app/environment';
 	import { Preferences } from '@capacitor/preferences';
 	import { apiFetch, checkAndRefreshToken } from '$lib/api';
@@ -101,8 +102,13 @@
 	});
 </script>
 
-{#if !check?.isConfigured}
-	<ConfigWizard />
-{:else}
-	{@render children()}
-{/if}
+<main>
+	{#if !check?.isConfigured}
+		<ConfigWizard />
+	{:else}
+		<div class="absolute top-4 right-4 z-50">
+			<LanguageSwitcher />
+		</div>
+		{@render children()}
+	{/if}
+</main>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,14 @@
+import { browser } from '$app/environment'
+import '$lib/i18n' // Import to initialize. Important :)
+import { locale, waitLocale } from 'svelte-i18n'
+import type { LayoutLoad } from './$types'
+
 export const prerender = true;
+
+export const load: LayoutLoad = async () => {
+	if (browser) {
+		const savedLocale = localStorage.getItem('selectedLocale');
+		locale.set(savedLocale || window.navigator.language)
+	}
+	await waitLocale()
+}

--- a/src/routes/components/SettingsPanel.svelte
+++ b/src/routes/components/SettingsPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import { Switch } from '$lib/components/ui/switch';
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
@@ -112,20 +113,20 @@
 	<!-- Model Size -->
 	<div class="space-y-2">
 		<Label class="text-sm text-gray-100"
-			>Model Size
+			>{$_('settings_panel.model_size.label')}
 			<Select.Root bind:value={transcriptionOptions.modelSize} type="single">
 				<Select.Trigger
 					class="border border-neutral-500/40 bg-neutral-900/40 shadow-lg backdrop-blur-md"
-					>{transcriptionOptions.modelSize}</Select.Trigger
+					>{$_(`settings_panel.model_size.${transcriptionOptions.modelSize}`)}</Select.Trigger
 				>
 				<Select.Content>
-					<Select.Item value="tiny">Tiny (Fast)</Select.Item>
-					<Select.Item value="base">Base (Balanced)</Select.Item>
-					<Select.Item value="small">Small (Better)</Select.Item>
-					<Select.Item value="medium">Medium (Good)</Select.Item>
-					<Select.Item value="large">Large (Best)</Select.Item>
-					<Select.Item value="large-v2">Large v2 (Enhanced)</Select.Item>
-					<Select.Item value="large-v3">Large v3 (Latest)</Select.Item>
+					<Select.Item value="tiny">{$_('settings_panel.model_size.tiny')}</Select.Item>
+					<Select.Item value="base">{$_('settings_panel.model_size.base')}</Select.Item>
+					<Select.Item value="small">{$_('settings_panel.model_size.small')}</Select.Item>
+					<Select.Item value="medium">{$_('settings_panel.model_size.medium')}</Select.Item>
+					<Select.Item value="large">{$_('settings_panel.model_size.large')}</Select.Item>
+					<Select.Item value="large-v2">{$_('settings_panel.model_size.large_v2')}</Select.Item>
+					<Select.Item value="large-v3">{$_('settings_panel.model_size.large_v3')}</Select.Item>
 				</Select.Content>
 			</Select.Root>
 		</Label>
@@ -134,16 +135,16 @@
 	<!-- Language -->
 	<div class="space-y-2">
 		<Label class="text-sm text-gray-100"
-			>Language
+			>{$_('settings_panel.language.label')}
 			<Select.Root bind:value={transcriptionOptions.language} type="single">
 				<Select.Trigger
 					class="border border-neutral-500/40 bg-neutral-900/40 shadow-lg backdrop-blur-md"
 				>
-					{WHISPER_LANGUAGES[transcriptionOptions.language]}
+					{transcriptionOptions.language === 'auto' ? $_('settings_panel.language.auto_detect') : WHISPER_LANGUAGES[transcriptionOptions.language]}
 				</Select.Trigger>
 				<Select.Content>
 					{#each Object.entries(WHISPER_LANGUAGES) as [code, name]}
-						<Select.Item value={code}>{name}</Select.Item>
+						<Select.Item value={code}>{code === 'auto' ? $_('settings_panel.language.auto_detect') : name}</Select.Item>
 					{/each}
 				</Select.Content>
 			</Select.Root>
@@ -153,15 +154,15 @@
 	<!-- CPU Threads -->
 	<div class="space-y-2">
 		<Label class="text-sm text-gray-100"
-			>CPU Threads
+			>{$_('settings_panel.cpu_threads.label')}
 			<Select.Root bind:value={transcriptionOptions.threads} type="single">
 				<Select.Trigger
 					class="border border-neutral-500/40 bg-neutral-900/40 shadow-lg backdrop-blur-md"
-					>{transcriptionOptions.threads} Threads</Select.Trigger
+					>{transcriptionOptions.threads} {$_('settings_panel.cpu_threads.suffix')}</Select.Trigger
 				>
 				<Select.Content>
 					{#each [1, 2, 4, 6, 8] as n}
-						<Select.Item value={n}>{n} Threads</Select.Item>
+						<Select.Item value={n}>{n} {$_('settings_panel.cpu_threads.suffix')}</Select.Item>
 					{/each}
 				</Select.Content>
 			</Select.Root>
@@ -171,15 +172,15 @@
 	<!-- CPU Processors -->
 	<div class="space-y-2">
 		<Label class="text-sm text-gray-100"
-			>CPU Processors
+			>{$_('settings_panel.cpu_processors.label')}
 			<Select.Root bind:value={transcriptionOptions.processors} type="single">
 				<Select.Trigger
 					class="border border-neutral-500/40 bg-neutral-900/40 shadow-lg backdrop-blur-md"
-					>{transcriptionOptions.processors} Processors</Select.Trigger
+					>{transcriptionOptions.processors} {$_('settings_panel.cpu_processors.suffix')}</Select.Trigger
 				>
 				<Select.Content>
 					{#each [1, 2, 3, 4] as n}
-						<Select.Item value={n}>{n} Processors</Select.Item>
+						<Select.Item value={n}>{n} {$_('settings_panel.cpu_processors.suffix')}</Select.Item>
 					{/each}
 				</Select.Content>
 			</Select.Root>
@@ -187,9 +188,8 @@
 	</div>
 
 	<!-- Diarization -->
-	<!-- Diarization -->
 	<div class="space-y-2">
-		<Label class="text-sm font-bold text-gray-50">Speaker Detection</Label>
+		<Label class="text-sm font-bold text-gray-50">{$_('settings_panel.speaker_detection.label')}</Label>
 		<div class="flex items-center space-x-2">
 			<Switch
 				id="diarization"
@@ -197,14 +197,13 @@
 				checked={transcriptionOptions.diarization}
 				onCheckedChange={(checked) => (transcriptionOptions.diarization = checked)}
 			/>
-			<Label for="diarization" class="text-sm text-gray-100">Enable speaker identification</Label>
+			<Label for="diarization" class="text-sm text-gray-100">{$_('settings_panel.speaker_detection.enable')}</Label>
 		</div>
 		{#if transcriptionOptions.diarization}
 			<div class="mt-2 rounded-md bg-amber-800/20 p-2 text-xs text-amber-400">
 				<p>
-					<strong>Note:</strong> Speaker detection requires a HuggingFace API token with access to 
-					<code>pyannote</code> models. Make sure to add your token to the <code>HUGGINGFACE_TOKEN</code>
-					environment variable in your <code>.env</code> file.
+					<strong>{$_('settings_panel.speaker_detection.note_title')}</strong>
+					{$_('settings_panel.speaker_detection.note_body')}
 				</p>
 			</div>
 		{/if}

--- a/src/routes/components/StatusPanel.svelte
+++ b/src/routes/components/StatusPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
+	import { get } from 'svelte/store';
 	import { onMount, onDestroy } from 'svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Progress } from '$lib/components/ui/progress';
@@ -91,7 +93,7 @@
 			activeJobs[id] = {
 				...activeJobs[id],
 				status: 'failed',
-				error: 'Lost connection to server'
+				error: get(_)('status_panel.errors.connection_lost')
 			};
 		};
 	}
@@ -121,7 +123,7 @@
 	class="mx-auto rounded-xl border border-neutral-300/30 bg-neutral-400/15 p-4 shadow-lg backdrop-blur-xl 2xl:w-[500px]"
 >
 	<Card.Content class="p-2">
-		<h2 class="prose-md prose text-gray-50">Active Transcription Jobs</h2>
+		<h2 class="prose-md prose text-gray-50">{$_('status_panel.title')}</h2>
 		<ScrollArea class="h-[300px] pt-4">
 			<div class="space-y-4">
 				{#each Object.entries(activeJobs) as [id, job]}
@@ -147,7 +149,7 @@
 								<div class="mt-4 space-y-1">
 									<Progress value={job.progress} class="h-2" />
 									<p class="text-right text-sm text-gray-300">
-										{job.progress}% {job.status === 'diarizing' ? 'analyzing' : 'transcribed'}
+										{job.progress}% {job.status === 'diarizing' ? $_('status_panel.progress.analyzing') : $_('status_panel.progress.transcribed')}
 									</p>
 								</div>
 							{/if}
@@ -162,7 +164,7 @@
 				{/each}
 
 				{#if Object.keys(activeJobs).length === 0}
-					<div class="text-center text-gray-500">No active transcription jobs</div>
+					<div class="text-center text-gray-500">{$_('status_panel.no_active_jobs')}</div>
 				{/if}
 			</div>
 		</ScrollArea>

--- a/src/routes/components/TemplatesList.svelte
+++ b/src/routes/components/TemplatesList.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
+	import { get } from 'svelte/store';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { ScrollArea } from '$lib/components/ui/scroll-area';
@@ -23,7 +25,7 @@
 		dialogOpen = false;
 		title = '';
 		prompt = '';
-		toast.success('Template created');
+		toast.success(get(_)('templates_list.toasts.created'));
 	}
 
 	let editingTitle = $state('');
@@ -72,9 +74,9 @@
 	<Card.Content class="p-2">
 		<div class="mb-4 text-lg font-bold text-white">
 			<div class="flex items-center justify-between">
-				<h3>Summary Templates</h3>
+				<h3>{$_('templates_list.title')}</h3>
 				<Button variant="secondary" size="sm" onclick={() => (dialogOpen = true)}>
-					<div>New</div>
+					<div>{$_('templates_list.new_button')}</div>
 					<CirclePlus size={16} class="text-blue-500" />
 				</Button>
 			</div>
@@ -142,25 +144,25 @@
 <Dialog.Root bind:open={dialogOpen}>
 	<Dialog.Content class="sm:max-w-[425px]">
 		<Dialog.Header>
-			<Dialog.Title>New Template</Dialog.Title>
+			<Dialog.Title>{$_('templates_list.new_dialog.title')}</Dialog.Title>
 		</Dialog.Header>
 
 		<form class="grid gap-4 py-4" onsubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
 			<Input
-				placeholder="Template Title"
+				placeholder={$_('templates_list.form.title_placeholder')}
 				bind:value={title}
 				required
 				class="text-gray-100 placeholder:text-gray-200"
 			/>
 			<Textarea
-				placeholder="Summarization Prompt"
+				placeholder={$_('templates_list.form.prompt_placeholder')}
 				bind:value={prompt}
 				required
 				class="min-h-[100px] text-gray-100 placeholder:text-gray-200"
 			/>
 			<Dialog.Footer>
 				<Button type="submit" class="bg-gray-300 text-gray-700 hover:bg-gray-400"
-					>Save Template</Button
+					>{$_('templates_list.form.save_button')}</Button
 				>
 			</Dialog.Footer>
 		</form>
@@ -170,25 +172,25 @@
 <Dialog.Root bind:open={editDialogOpen}>
 	<Dialog.Content class="sm:max-w-[425px]">
 		<Dialog.Header>
-			<Dialog.Title>Edit Template</Dialog.Title>
+			<Dialog.Title>{$_('templates_list.edit_dialog.title')}</Dialog.Title>
 		</Dialog.Header>
 
 		<form class="grid gap-4 py-4" onsubmit={(e) => { e.preventDefault(); handleEdit(); }}>
 			<Input
-				placeholder="Template Title"
+				placeholder={$_('templates_list.form.title_placeholder')}
 				bind:value={editingTitle}
 				required
 				class="text-gray-100"
 			/>
 			<Textarea
-				placeholder="Summarization Prompt"
+				placeholder={$_('templates_list.form.prompt_placeholder')}
 				bind:value={editingPrompt}
 				required
 				class="min-h-[100px] text-gray-100"
 			/>
 			<Dialog.Footer>
 				<Button type="submit" class="bg-gray-300 text-gray-700 hover:bg-gray-400 "
-					>Update Template</Button
+					>{$_('templates_list.form.update_button')}</Button
 				>
 			</Dialog.Footer>
 		</form>

--- a/src/routes/components/UploadPanel.svelte
+++ b/src/routes/components/UploadPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import * as Card from '$lib/components/ui/card';
 	import { audioFiles } from '$lib/stores/audioFiles';
 	import { Progress } from '$lib/components/ui/progress';
@@ -182,7 +183,7 @@
 		>
 			<Card.Content class="p-2">
 				<div class="flex items-center justify-between">
-					<h3 class="font-bold text-gray-50">Upload Audio</h3>
+					<h3 class="font-bold text-gray-50">{$_('upload_panel.title')}</h3>
 					<Button
 						variant="ghost"
 						size="icon"
@@ -213,10 +214,10 @@
 														<p class="font-medium text-gray-50">{fileName}</p>
 														<p class="text-sm text-gray-400">
 															{status.uploadStatus === 'uploading'
-																? 'Uploading...'
+																? $_('upload_panel.status.uploading')
 																: status.uploadStatus === 'success'
-																	? 'Upload complete'
-																	: 'Upload failed'}
+																	? $_('upload_panel.status.success')
+																	: $_('upload_panel.status.failed')}
 														</p>
 													</div>
 												</div>
@@ -254,8 +255,8 @@
 						>
 							<Upload class="h-8 w-8" />
 							<div>
-								<p class="text-lg font-medium">Drop audio files here</p>
-								<p class="text-sm text-gray-500">or click to select files</p>
+								<p class="text-lg font-medium">{$_('upload_panel.dropzone.prompt')}</p>
+								<p class="text-sm text-gray-500">{$_('upload_panel.dropzone.prompt_alt')}</p>
 							</div>
 						</div>
 					</Dropzone>

--- a/transcribe.sh
+++ b/transcribe.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Scriberr 自動化轉錄腳本
+#
+# 這個腳本會自動執行登入、上傳音檔、等待轉錄完成，並印出結果的完整流程。
+#
+# 使用方法:
+# ./transcribe.sh <音檔路徑>
+#
+# 範例:
+# ./transcribe.sh /path/to/your/audio.wav
+#
+# 前置需求:
+# - curl: 用於發送 API 請求。
+# - jq: 用於解析 JSON 回應。 (在大多數 Linux 發行版中可以透過 `sudo apt-get install jq` 或 `sudo yum install jq` 安裝)
+
+# --- 設定 ---
+SCRIBERR_URL="http://localhost:3000"
+USERNAME="admin"
+PASSWORD="password"
+LANGUAGE="en"
+MODEL_SIZE="base" # 可選 'tiny', 'base', 'small', 'medium', 'large'
+DIARIZATION="false" # 是否啟用說話人分離 (true/false)
+POLL_INTERVAL=15 # 輪詢間隔（秒）
+# --- 設定結束 ---
+
+# 檢查是否提供了音檔路徑
+if [ -z "$1" ]; then
+    echo "錯誤: 請提供音檔的路徑作為第一個參數。"
+    echo "用法: $0 <音檔路徑>"
+    exit 1
+fi
+
+AUDIO_FILE=$1
+
+# 檢查檔案是否存在
+if [ ! -f "$AUDIO_FILE" ]; then
+    echo "錯誤: 檔案 '$AUDIO_FILE' 不存在。"
+    exit 1
+fi
+
+echo "--- 1. 正在進行身分驗證... ---"
+AUTH_RESPONSE=$(curl -s -X POST "$SCRIBERR_URL/api/auth" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}")
+
+TOKEN=$(echo "$AUTH_RESPONSE" | jq -r .accessToken)
+
+if [ "$TOKEN" == "null" ] || [ -z "$TOKEN" ]; then
+    echo "錯誤: 身分驗證失敗。請檢查您的使用者名稱和密碼。"
+    echo "伺服器回應: $AUTH_RESPONSE"
+    exit 1
+fi
+
+echo "成功取得 Access Token。"
+echo
+
+echo "--- 2. 正在上傳檔案並啟動轉錄... ---"
+# 建立轉錄選項的 JSON 字串
+TRANSCRIPTION_OPTIONS=$(jq -n \
+    --arg lang "$LANGUAGE" \
+    --arg model "$MODEL_SIZE" \
+    --argjson diarize "$DIARIZATION" \
+    '{language: $lang, modelSize: $model, diarization: $diarize}')
+
+UPLOAD_RESPONSE=$(curl -s -X POST "$SCRIBERR_URL/api/upload" \
+    -H "Authorization: Bearer $TOKEN" \
+    -F "file=@$AUDIO_FILE" \
+    -F "options=$TRANSCRIPTION_OPTIONS")
+
+JOB_ID=$(echo "$UPLOAD_RESPONSE" | jq -r .id)
+
+if [ "$JOB_ID" == "null" ] || [ -z "$JOB_ID" ]; then
+    echo "錯誤: 檔案上傳失敗。"
+    echo "伺服器回應: $UPLOAD_RESPONSE"
+    exit 1
+fi
+
+echo "檔案上傳成功。轉錄工作 ID: $JOB_ID"
+echo
+
+echo "--- 3. 正在等待轉錄結果 (每 $POLL_INTERVAL 秒查詢一次)... ---"
+while true; do
+    STATUS_RESPONSE=$(curl -s -X GET "$SCRIBERR_URL/api/transcription/$JOB_ID" \
+        -H "Authorization: Bearer $TOKEN")
+
+    STATUS=$(echo "$STATUS_RESPONSE" | jq -r .status)
+    echo "目前狀態: $STATUS..."
+
+    if [ "$STATUS" == "completed" ]; then
+        echo
+        echo "--- 轉錄完成！ ---"
+        TRANSCRIPT=$(echo "$STATUS_RESPONSE" | jq -r .transcript.text)
+        echo "$TRANSCRIPT"
+        exit 0
+    elif [ "$STATUS" == "failed" ]; then
+        echo
+        echo "--- 轉錄失敗！ ---"
+        ERROR_MESSAGE=$(echo "$STATUS_RESPONSE" | jq -r .error)
+        echo "錯誤訊息: $ERROR_MESSAGE"
+        exit 1
+    fi
+
+    sleep $POLL_INTERVAL
+done


### PR DESCRIPTION
This commit introduces an internationalization (i18n) framework to the application and provides an initial Traditional Chinese (zh-TW) translation for several key components. It also includes a previously completed task to add a bash script for automating transcriptions.

Key changes include:

1.  **Automation Script (`transcribe.sh`):**
    *   Added a new bash script (`transcribe.sh`) that uses the project's API to automate the process of uploading an audio file and retrieving its transcription.

2.  **Internationalization (i18n) Setup:**
    *   Installed and configured the `svelte-i18n` library for SvelteKit.
    *   Added locale files for English (`en.json`) and Traditional Chinese (`zh-TW.json`).
    *   Implemented a `LanguageSwitcher.svelte` component to allow users to change the language, with the preference saved to localStorage.

3.  **Component Translation:**
    *   Refactored several components to use the new i18n framework, replacing hardcoded English strings with localization keys.
    *   Translated components: `UploadPanel`, `SettingsPanel`, `StatusPanel`, and `TemplatesList`.

**Obstacles Encountered:**
A persistent issue with the file editing tools prevented modification of large files like `src/hooks.server.ts` and `src/routes/+page.svelte`.
*   **Server-Side Rendering:** The inability to modify `src/hooks.server.ts` blocked the implementation of server-side language detection. The current solution is client-side only, which may result in a brief flash of English content before the UI switches to the user's preferred language.
*   **Main Page Translation:** The same issue blocked the translation of the main dashboard page (`+page.svelte`). The current work focused on translating smaller, self-contained components as a workaround.

Further work would be needed to resolve the tooling issue and complete the translation of the remaining components.