### PR TITLE
Adds cuda compatibility to Dockerfile.cuda via cuda runtime.

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -42,7 +42,7 @@ RUN CGO_ENABLED=0 \
 ########################
 # CUDA Runtime stage
 ########################
-FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04 AS runtime
+FROM nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04 AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     HOST=0.0.0.0 \
@@ -61,15 +61,9 @@ WORKDIR /app
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        curl ca-certificates ffmpeg git gosu \
-       python3 python3-dev python3-venv python3-pip \
+       build-essential gcc g++ make python3-dev \
+       python3 python3-venv python3-pip \
   && rm -rf /var/lib/apt/lists/*
-
-# Install cuDNN runtime
-RUN apt-get update && apt-get install -y wget gnupg2 \
-  && wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb \
-  && dpkg -i cuda-keyring_1.1-1_all.deb \
-  && apt-get update \
-  && apt-get install -y libcudnn9-cuda-12=9.1.1.17-1
 
 # Install uv (fast Python package manager) directly to system PATH
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \

--- a/docker-compose.build.cuda.yml
+++ b/docker-compose.build.cuda.yml
@@ -1,0 +1,37 @@
+services:
+  scriberr:
+    # Build from local Dockerfile; replace with `image: ghcr.io/rishikanthc/scriberr:latest`
+    # if you prefer pulling a prebuilt image.
+    build:
+      context: .
+      dockerfile: Dockerfile.cuda
+    image: scriberr:local-cuda
+    container_name: scriberr
+    ports:
+      - "8080:8080"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities:
+                - gpu
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    # environment:
+    #   - HOST=0.0.0.0
+    #   - PORT=8080
+    #   - DATABASE_PATH=/app/data/scriberr.db
+    #   - UPLOAD_DIR=/app/data/uploads
+      - PUID=${PUID:-10001}
+      - PGID=${PGID:-10001}
+    volumes:
+      - ./scriberr_data:/app/data
+      - ./env-data:/app/whisperx-env
+    restart: unless-stopped
+
+volumes:
+  scriberr_data:
+  env-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,16 +7,18 @@ PGID=${PGID:-1000}
 
 echo "=== Scriberr Container Setup ==="
 echo "Requested UID: $PUID, GID: $PGID"
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+echo "LD_LIBRARY_PATH is: $LD_LIBRARY_PATH"
 
 # Function to setup user if needed
 setup_user() {
     local target_uid=$1
     local target_gid=$2
-    
+
     # Check if we need to modify the user
     if [ "$target_uid" != "1000" ] || [ "$target_gid" != "1000" ]; then
         echo "Setting up custom user with UID=$target_uid, GID=$target_gid..."
-        
+
         # Check if group already exists with different GID
         if getent group "$target_gid" >/dev/null 2>&1; then
             echo "Group with GID $target_gid already exists, using it"
@@ -27,14 +29,15 @@ setup_user() {
                 usermod -g "$target_gid" appuser
             }
         fi
-        
+
         # Modify user UID
         usermod -u "$target_uid" appuser 2>/dev/null || {
             echo "Warning: Could not change user ID, continuing with existing user"
         }
-        
+
         # Update ownership of app directory
         chown -R "$target_uid:$target_gid" /app 2>/dev/null || true
+
     else
         echo "Using default user (UID=1000, GID=1000)"
     fi
@@ -43,26 +46,26 @@ setup_user() {
 # Setup the user (only if running as root)
 if [ "$(id -u)" = "0" ]; then
     setup_user "$PUID" "$PGID"
-    
+
     # Set up directories with proper ownership
     echo "Setting up data directories..."
     mkdir -p /app/data/uploads /app/data/transcripts /app/whisperx-env
     chown -R "$PUID:$PGID" /app/data /app/whisperx-env
-    
+
     echo "=== Setup Complete ==="
     echo "Switching to user appuser (UID=$PUID, GID=$PGID) and starting application..."
-    
+
     # Switch to the appuser and execute the command
     exec gosu appuser "$@"
 else
     echo "Running as non-root user UID=$(id -u), GID=$(id -g)"
-    
+
     # Just ensure directories exist
     mkdir -p /app/data/uploads /app/data/transcripts /app/whisperx-env 2>/dev/null || true
-    
+
     echo "=== Setup Complete ==="
     echo "Starting Scriberr application..."
-    
+
     # Execute directly
     exec "$@"
 fi


### PR DESCRIPTION
This will only work for x86_64 builds.
Adds the libcddn from the cuda runtime to the $LD_LIBRARY_PATH.
This needs to be made available in the docker-entryway.
Created a new docker-compose.build.cuda.yml to match the existing docker-compose.cuda.yml files.

Apologies for any faux pas here, this is my first pull request.