### PR TITLE
Fix MP4 file upload validation in audio upload handler

### DIFF
--- a/web/frontend/src/components/Header.tsx
+++ b/web/frontend/src/components/Header.tsx
@@ -14,6 +14,7 @@ import { QuickTranscriptionDialog } from "./QuickTranscriptionDialog";
 import { YouTubeDownloadDialog } from "./YouTubeDownloadDialog";
 import { useRouter } from "../contexts/RouterContext";
 import { useAuth } from "../contexts/AuthContext";
+import { isVideoFile, isAudioFile } from "../utils/fileProcessor";
 
 interface FileWithType {
 	file: File;
@@ -74,11 +75,25 @@ export function Header({ onFileSelect, onMultiTrackClick, onDownloadComplete }: 
 	const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const files = event.target.files;
 		if (files && files.length > 0) {
+			const fileArray = Array.from(files);
+
+			// Check for video files that were incorrectly uploaded via audio upload
+			const videoFiles = fileArray.filter(file => isVideoFile(file));
+			if (videoFiles.length > 0) {
+				alert(`Video files detected. Please use "Upload Videos" instead of "Upload Files" to upload ${videoFiles.map(f => f.name).join(', ')}`);
+				event.target.value = "";
+				return;
+			}
+
 			// Filter to only audio files
-			const audioFiles = Array.from(files).filter(file => file.type.startsWith("audio/"));
+			const audioFiles = fileArray.filter(file => isAudioFile(file));
 			if (audioFiles.length > 0) {
 				onFileSelect(audioFiles.length === 1 ? audioFiles[0] : audioFiles);
 				// Reset the input so the same files can be selected again
+				event.target.value = "";
+			} else {
+				// No valid audio files found
+				alert("No valid audio files found. Please select audio files (.mp3, .wav, .flac, .m4a, .aac, .ogg)");
 				event.target.value = "";
 			}
 		}


### PR DESCRIPTION
Hey, me again. This was a minor error but turned out to be an easy fix - I will work through a few more but thought I'd get this up there instead of submitting a monolithic PR. I used Claude Code to run my tests, troubleshoot errors, and automate my workflow but it is otherwise me fixing the code and verifying it, just wanted you to know since we live in the AI era now :) Cheers!

## Problem

When users try to upload MP4 files through the "Upload Files" option, the files fail silently without any error message. This creates a confusing user experience.

## Root Cause

The original validation only checked the file MIME type (`file.type.startsWith("audio/")`). Browsers don't always set the correct MIME type for files, especially video files, so MP4 files would bypass both the audio filter and any error handling, resulting in silent failure.

## Solution

Updated the file validation in Header.tsx to use the existing utility functions from fileProcessor.ts:
- `isVideoFile()` checks both MIME type and file extension (.mp4, .avi, .mov, etc.)
- `isAudioFile()` checks both MIME type and file extension (.mp3, .wav, etc.)

Now when users upload video files through "Upload Files":
1. The system detects them regardless of MIME type
2. Shows a clear error message: "Video files detected. Please use 'Upload Videos' instead"
3. Lists the filenames that were rejected

Also added a fallback error message if no valid audio files are found at all.

## Testing

Tested locally by attempting to upload an MP4 file through "Upload Files" - correctly shows error message and prevents silent failure.