### PR TITLE
Fix CUDA Error 35 on Parakeet for short audio (<300s)

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -60,7 +60,7 @@ WORKDIR /app
 # Ubuntu 24.04 comes with Python 3.12 which works fine with WhisperX
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-       curl ca-certificates ffmpeg git gosu \
+       curl ca-certificates ffmpeg git gosu unzip \
        build-essential gcc g++ make python3-dev \
        python3 python3-venv python3-pip \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hey, found a silly error I made when fixing the CUDA Error 35 issue earlier - I only applied the fix to the buffered transcription path (audio over 5 minutes), but completely missed the regular transcription path for shorter audio. So short files were still crashing.

This applies the same CUDA graph workaround to both paths so it works for all audio lengths.

Also fixed the Deno installation issue (needed unzip package in Dockerfile).

Tested with various audio lengths and it's working now.