### PR TITLE
fix: downgrade cuda base image and remove conflicting LD_LIBRARY_PATH - fixes #273 , fixes #104 , fixes #246

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -47,7 +47,7 @@ RUN mkdir -p /out/bin/cli \
 ########################
 # CUDA Runtime stage
 ########################
-FROM nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04 AS runtime
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04 AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     HOST=0.0.0.0 \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,8 +7,8 @@ PGID=${PGID:-1000}
 
 echo "=== Scriberr Container Setup ==="
 echo "Requested UID: $PUID, GID: $PGID"
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
-echo "LD_LIBRARY_PATH is: $LD_LIBRARY_PATH"
+# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+# echo "LD_LIBRARY_PATH is: $LD_LIBRARY_PATH"
 
 # Function to setup user if needed
 setup_user() {


### PR DESCRIPTION
This PR downgrades cudnn from 12.9 to 12.6.3 to allow compatibility for older NVIDIA cards.
Fixes #273 , Fixes #104 , Fixes #246 