### PR TITLE
Configurable OpenAI API Base URL

### DIFF
--- a/internal/api/chat_handlers.go
+++ b/internal/api/chat_handlers.go
@@ -88,7 +88,7 @@ func (h *Handler) getLLMService(ctx context.Context) (llm.Service, string, error
 		if cfg.APIKey == nil || *cfg.APIKey == "" {
 			return nil, cfg.Provider, fmt.Errorf("OpenAI API key not configured")
 		}
-		return llm.NewOpenAIService(*cfg.APIKey), cfg.Provider, nil
+		return llm.NewOpenAIService(*cfg.APIKey, cfg.OpenAIBaseURL), cfg.Provider, nil
 	case "ollama":
 		if cfg.BaseURL == nil || *cfg.BaseURL == "" {
 			return nil, cfg.Provider, fmt.Errorf("Ollama base URL not configured")

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -21,10 +21,14 @@ type OpenAIService struct {
 }
 
 // NewOpenAIService creates a new OpenAI service
-func NewOpenAIService(apiKey string) *OpenAIService {
+func NewOpenAIService(apiKey string, baseURL *string) *OpenAIService {
+	url := "https://api.openai.com/v1"
+	if baseURL != nil && *baseURL != "" {
+		url = *baseURL
+	}
 	return &OpenAIService{
 		apiKey:  apiKey,
-		baseURL: "https://api.openai.com/v1",
+		baseURL: url,
 		client: &http.Client{
 			Timeout: 300 * time.Second,
 		},

--- a/internal/models/transcription.go
+++ b/internal/models/transcription.go
@@ -202,13 +202,14 @@ func (tp *TranscriptionProfile) BeforeSave(tx *gorm.DB) error {
 
 // LLMConfig represents LLM configuration settings
 type LLMConfig struct {
-	ID        uint      `json:"id" gorm:"primaryKey"`
-	Provider  string    `json:"provider" gorm:"not null;type:varchar(50)"` // "ollama" or "openai"
-	BaseURL   *string   `json:"base_url,omitempty" gorm:"type:text"`       // For Ollama
-	APIKey    *string   `json:"api_key,omitempty" gorm:"type:text"`        // For OpenAI (encrypted)
-	IsActive  bool      `json:"is_active" gorm:"type:boolean;default:false"`
-	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
-	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
+	ID            uint      `json:"id" gorm:"primaryKey"`
+	Provider      string    `json:"provider" gorm:"not null;type:varchar(50)"` // "ollama" or "openai"
+	BaseURL       *string   `json:"base_url,omitempty" gorm:"type:text"`       // For Ollama
+	OpenAIBaseURL *string   `json:"openai_base_url,omitempty" gorm:"type:text"` // For OpenAI custom endpoint
+	APIKey        *string   `json:"api_key,omitempty" gorm:"type:text"`        // For OpenAI (encrypted)
+	IsActive      bool      `json:"is_active" gorm:"type:boolean;default:false"`
+	CreatedAt     time.Time `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt     time.Time `json:"updated_at" gorm:"autoUpdateTime"`
 }
 
 // BeforeSave ensures only one LLM config can be active

--- a/web/frontend/src/components/LLMSettings.tsx
+++ b/web/frontend/src/components/LLMSettings.tsx
@@ -10,6 +10,7 @@ interface LLMConfig {
 	id?: number;
 	provider: string;
 	base_url?: string;
+	openai_base_url?: string;
 	has_api_key?: boolean;
 	is_active: boolean;
 	created_at?: string;
@@ -22,6 +23,7 @@ export function LLMSettings() {
 		is_active: false,
 	});
 	const [baseUrl, setBaseUrl] = useState("");
+	const [openAIBaseUrl, setOpenAIBaseUrl] = useState("");
 	const [apiKey, setApiKey] = useState("");
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
@@ -42,6 +44,7 @@ export function LLMSettings() {
 				const data = await response.json();
 				setConfig(data);
 				setBaseUrl(data.base_url || "");
+				setOpenAIBaseUrl(data.openai_base_url || "");
 				// Don't set API key from response for security
 			} else if (response.status !== 404) {
 				console.error("Failed to fetch LLM config");
@@ -61,7 +64,10 @@ export function LLMSettings() {
 			provider: config.provider,
 			is_active: true, // Always set to active when saving
 			...(config.provider === "ollama" && { base_url: baseUrl }),
-			...(config.provider === "openai" && { api_key: apiKey }),
+			...(config.provider === "openai" && {
+				api_key: apiKey,
+				openai_base_url: openAIBaseUrl
+			}),
 		};
 
 		try {
@@ -228,27 +234,44 @@ export function LLMSettings() {
 						)}
 
 						{config.provider === "openai" && (
-							<div>
-								<Label htmlFor="apiKey" className="flex items-center gap-2">
-									<Key className="h-4 w-4" />
-									OpenAI API Key *
-									{config.has_api_key && (
-										<span className="text-xs bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-1 rounded">
-											Already configured
-										</span>
-									)}
-								</Label>
-								<Input
-									id="apiKey"
-									type="password"
-									placeholder={config.has_api_key ? "Enter new API key to update" : "sk-..."}
-									value={apiKey}
-									onChange={(e) => setApiKey(e.target.value)}
-									className="mt-1"
-								/>
-								<p className="text-xs text-carbon-500 dark:text-carbon-400 mt-1">
-									Your OpenAI API key. {config.has_api_key ? "Leave blank to keep current key." : ""}
-								</p>
+							<div className="space-y-4">
+								<div>
+									<Label htmlFor="apiKey" className="flex items-center gap-2">
+										<Key className="h-4 w-4" />
+										OpenAI API Key *
+										{config.has_api_key && (
+											<span className="text-xs bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-1 rounded">
+												Already configured
+											</span>
+										)}
+									</Label>
+									<Input
+										id="apiKey"
+										type="password"
+										placeholder={config.has_api_key ? "Enter new API key to update" : "sk-..."}
+										value={apiKey}
+										onChange={(e) => setApiKey(e.target.value)}
+										className="mt-1"
+									/>
+									<p className="text-xs text-carbon-500 dark:text-carbon-400 mt-1">
+										Your OpenAI API key. {config.has_api_key ? "Leave blank to keep current key." : ""}
+									</p>
+								</div>
+
+								<div>
+									<Label htmlFor="openAIBaseUrl">OpenAI Base URL (Optional)</Label>
+									<Input
+										id="openAIBaseUrl"
+										type="url"
+										placeholder="https://api.openai.com/v1"
+										value={openAIBaseUrl}
+										onChange={(e) => setOpenAIBaseUrl(e.target.value)}
+										className="mt-1"
+									/>
+									<p className="text-xs text-carbon-500 dark:text-carbon-400 mt-1">
+										Custom endpoint URL for OpenAI-compatible services. Leave blank for default.
+									</p>
+								</div>
 							</div>
 						)}
 					</div>


### PR DESCRIPTION
Fix for enhancement issue #194

Added option to use custom OpenAI API base URL.

If not configured the default OpenAI API base URL (https://api.openai.com/v1) will be used.

Does not change current behavior of apiKey, i.e if apiKey is already configured it will not have to be re-entered when modifying base URL.

<img width="1202" height="977" alt="image" src="https://github.com/user-attachments/assets/4acb2556-3dc6-45fc-bd72-206cc783cb65" />
