### PR TITLE
Show all models when using custom OpenAI compatible endpoint in LLM

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -123,12 +123,18 @@ func (s *OpenAIService) GetModels(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	// Filter for chat models (GPT models)
+	useDefault := s.baseURL == "https://api.openai.com/v1"
 	var chatModels []string
 	for _, model := range modelsResp.Data {
-		if strings.Contains(model.ID, "gpt") {
+		if useDefault {
+			// Filter for chat models (GPT models) if default OpenAI baseURL
+			if strings.Contains(model.ID, "gpt") {
+				chatModels = append(chatModels, model.ID)
+			}
+		} else {
+			// If custom baseURL → return all models
 			chatModels = append(chatModels, model.ID)
-		}
+    	}
 	}
 
 	return chatModels, nil


### PR DESCRIPTION
If OpenAI LLM endpoint is default, filter for chat models.
If using custom OpenAI LLM endpoint show all models.

See issue #300 