### PR TITLE
Re-add Rename Speaker Dialog to dropdown menu

### DIFF
--- a/web/frontend/src/features/transcription/components/AudioDetailView.tsx
+++ b/web/frontend/src/features/transcription/components/AudioDetailView.tsx
@@ -12,7 +12,7 @@ import { EmberPlayer, type EmberPlayerRef } from "@/components/audio/EmberPlayer
 import { cn } from "@/lib/utils";
 
 // Custom Hooks
-import { useAudioDetail, useUpdateTitle, useTranscript } from "@/features/transcription/hooks/useAudioDetail";
+import { useAudioDetail, useUpdateTitle, useTranscript, type TranscriptSegment } from "@/features/transcription/hooks/useAudioDetail";
 import { useSpeakerMappings } from "@/features/transcription/hooks/useTranscriptionSpeakers";
 import { useTranscriptDownload } from "@/features/transcription/hooks/useTranscriptDownload";
 
@@ -312,13 +312,12 @@ export const AudioDetailView = function AudioDetailView({ audioId: propAudioId }
                                                         <MessageCircle className={cn("mr-2 h-4 w-4 opacity-70", chatOpen && "text-[var(--brand-solid)]")} />
                                                         Chat with Audio
                                                     </DropdownMenuItem>
-                                                    {transcript?.segments?.some((s: any) => s.speaker) && (
+                                                    {transcript?.segments?.some((s: TranscriptSegment) => s.speaker) && (
                                                         <DropdownMenuItem onClick={() => setSpeakerRenameOpen(true)} className="rounded-[8px] cursor-pointer">
                                                             <Users className="mr-2 h-4 w-4 opacity-70" />
                                                             Rename Speakers
                                                         </DropdownMenuItem>
                                                     )}
-                                                    <DropdownMenuSeparator className="bg-[var(--border-subtle)] my-1" />
                                                     <DropdownMenuItem onClick={() => setSummaryDialogOpen(true)} className="rounded-[8px] cursor-pointer text-[var(--brand-solid)] focus:text-[var(--brand-solid)] focus:bg-[var(--brand-light)]">
                                                         <Bot className="mr-2 h-4 w-4" /> AI Summary
                                                     </DropdownMenuItem>

--- a/web/frontend/src/features/transcription/hooks/useAudioDetail.ts
+++ b/web/frontend/src/features/transcription/hooks/useAudioDetail.ts
@@ -75,14 +75,16 @@ export interface WordSegment {
     speaker?: string;
 }
 
+export interface TranscriptSegment {
+    start: number;
+    end: number;
+    text: string;
+    speaker?: string;
+}
+
 export interface Transcript {
     text: string;
-    segments?: Array<{
-        start: number;
-        end: number;
-        text: string;
-        speaker?: string;
-    }>;
+    segments?: TranscriptSegment[];
     word_segments?: WordSegment[];
 }
 


### PR DESCRIPTION
I noticed it disappeared.

I suppose that `{/* ... Rest of menu items ... */}`  was carrying some weight 🤣 


I doublechecked against https://github.com/rishikanthc/Scriberr/commit/938a010416511e7a0a72d8e1740d5d5383c67d96?diff=split to see if anything else was left out.. Nothing was (aside from the section headings... and they don't add much)

