### PR TITLE
feat: expand language support in the UI to 58 languages for Whisper and OpenAI models

### DIFF
--- a/web/frontend/src/components/transcription/TranscriptionConfigDialog.tsx
+++ b/web/frontend/src/components/transcription/TranscriptionConfigDialog.tsx
@@ -150,6 +150,74 @@ const WHISPER_MODELS = [
 
 const LANGUAGES = [
     { value: "auto", label: "Auto-detect" },
+    { value: "af", label: "Afrikaans" },
+    { value: "ar", label: "Arabic" },
+    { value: "hy", label: "Armenian" },
+    { value: "az", label: "Azerbaijani" },
+    { value: "be", label: "Belarusian" },
+    { value: "bs", label: "Bosnian" },
+    { value: "bg", label: "Bulgarian" },
+    { value: "ca", label: "Catalan" },
+    { value: "zh", label: "Chinese" },
+    { value: "hr", label: "Croatian" },
+    { value: "cs", label: "Czech" },
+    { value: "da", label: "Danish" },
+    { value: "nl", label: "Dutch" },
+    { value: "en", label: "English" },
+    { value: "et", label: "Estonian" },
+    { value: "fi", label: "Finnish" },
+    { value: "fr", label: "French" },
+    { value: "gl", label: "Galician" },
+    { value: "de", label: "German" },
+    { value: "el", label: "Greek" },
+    { value: "he", label: "Hebrew" },
+    { value: "hi", label: "Hindi" },
+    { value: "hu", label: "Hungarian" },
+    { value: "is", label: "Icelandic" },
+    { value: "id", label: "Indonesian" },
+    { value: "it", label: "Italian" },
+    { value: "ja", label: "Japanese" },
+    { value: "kn", label: "Kannada" },
+    { value: "kk", label: "Kazakh" },
+    { value: "ko", label: "Korean" },
+    { value: "lv", label: "Latvian" },
+    { value: "lt", label: "Lithuanian" },
+    { value: "mk", label: "Macedonian" },
+    { value: "ms", label: "Malay" },
+    { value: "mr", label: "Marathi" },
+    { value: "mi", label: "Maori" },
+    { value: "ne", label: "Nepali" },
+    { value: "no", label: "Norwegian" },
+    { value: "fa", label: "Persian" },
+    { value: "pl", label: "Polish" },
+    { value: "pt", label: "Portuguese" },
+    { value: "ro", label: "Romanian" },
+    { value: "ru", label: "Russian" },
+    { value: "sr", label: "Serbian" },
+    { value: "sk", label: "Slovak" },
+    { value: "sl", label: "Slovenian" },
+    { value: "es", label: "Spanish" },
+    { value: "sw", label: "Swahili" },
+    { value: "sv", label: "Swedish" },
+    { value: "tl", label: "Tagalog" },
+    { value: "ta", label: "Tamil" },
+    { value: "th", label: "Thai" },
+    { value: "tr", label: "Turkish" },
+    { value: "uk", label: "Ukrainian" },
+    { value: "ur", label: "Urdu" },
+    { value: "vi", label: "Vietnamese" },
+    { value: "cy", label: "Welsh" },
+];
+
+const CANARY_LANGUAGES = [
+    { value: "en", label: "English" },
+    { value: "de", label: "German" },
+    { value: "es", label: "Spanish" },
+    { value: "fr", label: "French" },
+];
+
+const VOXTRAL_LANGUAGES = [
+    { value: "auto", label: "Auto-detect" },
     { value: "en", label: "English" },
     { value: "zh", label: "Chinese" },
     { value: "de", label: "German" },
@@ -172,13 +240,6 @@ const LANGUAGES = [
     { value: "he", label: "Hebrew" },
     { value: "uk", label: "Ukrainian" },
     { value: "el", label: "Greek" },
-];
-
-const CANARY_LANGUAGES = [
-    { value: "en", label: "English" },
-    { value: "de", label: "German" },
-    { value: "es", label: "Spanish" },
-    { value: "fr", label: "French" },
 ];
 
 const PARAM_DESCRIPTIONS = {
@@ -1020,7 +1081,7 @@ function VoxtralConfig({ params, updateParam }: ConfigProps) {
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent className={selectContentClassName}>
-                            {LANGUAGES.map((l) => (
+                            {VOXTRAL_LANGUAGES.map((l) => (
                                 <SelectItem key={l.value} value={l.value} className={selectItemClassName}>{l.label}</SelectItem>
                             ))}
                         </SelectContent>


### PR DESCRIPTION
Expands language selection from 24 to 58 languages for Whisper and OpenAI transcription profiles.

Changes:
- Expand LANGUAGES array to 58 languages (all with WER >50%) as per https://platform.openai.com/docs/guides/speech-to-text#supported-languages
- Add 34 new languages including Afrikaans, Armenian, Czech, Danish, Hungarian, Norwegian, Romanian, Serbian, Slovak, Thai, and many more
- Create VOXTRAL_LANGUAGES array with original 24-language subset for Voxtral
- Update VoxtralConfig to use VOXTRAL_LANGUAGES instead of LANGUAGES
- All languages alphabetically sorted

Language array usage:
- LANGUAGES (58) → Whisper and OpenAI models
- VOXTRAL_LANGUAGES (24) → Voxtral model
- CANARY_LANGUAGES (4) → NVIDIA Canary model