### PR TITLE
fix: make transcription temp and output directories configurable

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -116,9 +116,7 @@ func main() {
 
 	// Initialize unified transcription processor
 	logger.Startup("transcription", "Initializing transcription service")
-	// Initialize unified transcription processor
-	logger.Startup("transcription", "Initializing transcription service")
-	unifiedProcessor := transcription.NewUnifiedJobProcessor(jobRepo)
+	unifiedProcessor := transcription.NewUnifiedJobProcessor(jobRepo, cfg.TempDir, cfg.TranscriptsDir)
 	unifiedProcessor.GetUnifiedService().SetBroadcaster(broadcaster)
 
 	// Bootstrap embedded Python environment (for all adapters)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	// File storage
 	UploadDir      string
 	TranscriptsDir string
+	TempDir        string
 
 	// Python/WhisperX configuration
 	WhisperXEnv string
@@ -61,6 +62,7 @@ func Load() *Config {
 		JWTSecret:      getJWTSecret(),
 		UploadDir:      getEnv("UPLOAD_DIR", "data/uploads"),
 		TranscriptsDir: getEnv("TRANSCRIPTS_DIR", "data/transcripts"),
+		TempDir:        getEnv("TEMP_DIR", "data/temp"),
 		WhisperXEnv:    getEnv("WHISPERX_ENV", "data/whisperx-env"),
 		SecureCookies:  getEnv("SECURE_COOKIES", defaultSecure) == "true",
 		OpenAIAPIKey:   getEnv("OPENAI_API_KEY", ""),

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"scriberr/internal/models"
@@ -21,8 +22,9 @@ func Initialize(dbPath string) error {
 	var err error
 
 	// Create database directory if it doesn't exist
-	if err := os.MkdirAll("data", 0755); err != nil {
-		return fmt.Errorf("failed to create data directory: %v", err)
+	dbDir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		return fmt.Errorf("failed to create database directory: %v", err)
 	}
 
 	// SQLite connection string with performance optimizations

--- a/internal/transcription/adapters_test.go
+++ b/internal/transcription/adapters_test.go
@@ -466,7 +466,7 @@ func TestUnifiedTranscriptionService(t *testing.T) {
 
 	// Create unified service with mock repo
 	mockRepo := new(MockJobRepository)
-	service := NewUnifiedTranscriptionService(mockRepo)
+	service := NewUnifiedTranscriptionService(mockRepo, "data/temp", "data/transcripts")
 
 	// Test model discovery
 	models := service.GetSupportedModels()
@@ -486,7 +486,7 @@ func TestUnifiedTranscriptionService(t *testing.T) {
 
 func TestAudioInputCreation(t *testing.T) {
 	mockRepo := new(MockJobRepository)
-	service := NewUnifiedTranscriptionService(mockRepo)
+	service := NewUnifiedTranscriptionService(mockRepo, "data/temp", "data/transcripts")
 
 	// Test creating audio input from a hypothetical file
 	audioPath := "/tmp/test.wav"
@@ -500,7 +500,7 @@ func TestAudioInputCreation(t *testing.T) {
 
 func TestParameterConversion(t *testing.T) {
 	mockRepo := new(MockJobRepository)
-	service := NewUnifiedTranscriptionService(mockRepo)
+	service := NewUnifiedTranscriptionService(mockRepo, "data/temp", "data/transcripts")
 
 	// Test converting WhisperX parameters to generic map
 	params := models.WhisperXParams{

--- a/internal/transcription/queue_integration.go
+++ b/internal/transcription/queue_integration.go
@@ -14,9 +14,9 @@ type UnifiedJobProcessor struct {
 }
 
 // NewUnifiedJobProcessor creates a new job processor using the unified service
-func NewUnifiedJobProcessor(jobRepo repository.JobRepository) *UnifiedJobProcessor {
+func NewUnifiedJobProcessor(jobRepo repository.JobRepository, tempDir, outputDir string) *UnifiedJobProcessor {
 	return &UnifiedJobProcessor{
-		unifiedService: NewUnifiedTranscriptionService(jobRepo),
+		unifiedService: NewUnifiedTranscriptionService(jobRepo, tempDir, outputDir),
 	}
 }
 

--- a/internal/transcription/unified_service.go
+++ b/internal/transcription/unified_service.go
@@ -55,14 +55,14 @@ type UnifiedTranscriptionService struct {
 }
 
 // NewUnifiedTranscriptionService creates a new unified transcription service
-func NewUnifiedTranscriptionService(jobRepo repository.JobRepository) *UnifiedTranscriptionService {
+func NewUnifiedTranscriptionService(jobRepo repository.JobRepository, tempDir, outputDir string) *UnifiedTranscriptionService {
 	return &UnifiedTranscriptionService{
 		registry:        registry.GetRegistry(),
 		pipeline:        pipeline.NewProcessingPipeline(),
 		preprocessors:   make(map[string]interfaces.Preprocessor),
 		postprocessors:  make(map[string]interfaces.Postprocessor),
-		tempDirectory:   "data/temp",
-		outputDirectory: "data/transcripts",
+		tempDirectory:   tempDir,
+		outputDirectory: outputDir,
 		defaultModelIDs: map[string]string{
 			"transcription": ModelWhisperX,
 			"diarization":   ModelPyannote,

--- a/internal/transcription/webhook_integration_test.go
+++ b/internal/transcription/webhook_integration_test.go
@@ -34,7 +34,7 @@ func TestWebhookIntegration_Failure(t *testing.T) {
 	defer server.Close()
 
 	// Setup service
-	service := NewUnifiedTranscriptionService(mockRepo)
+	service := NewUnifiedTranscriptionService(mockRepo, "data/temp", "data/transcripts")
 
 	// Setup test job
 	callbackURL := server.URL

--- a/tests/api_handlers_test.go
+++ b/tests/api_handlers_test.go
@@ -59,7 +59,7 @@ func (suite *APIHandlerTestSuite) SetupSuite() {
 	fileService := service.NewFileService()
 
 	// Initialize services
-	suite.unifiedProcessor = transcription.NewUnifiedJobProcessor(jobRepo)
+	suite.unifiedProcessor = transcription.NewUnifiedJobProcessor(jobRepo, suite.helper.Config.TempDir, suite.helper.Config.TranscriptsDir)
 	var err error
 	suite.quickTranscription, err = transcription.NewQuickTranscriptionService(suite.helper.Config, suite.unifiedProcessor, jobRepo)
 	assert.NoError(suite.T(), err)

--- a/tests/cli_handlers_test.go
+++ b/tests/cli_handlers_test.go
@@ -52,7 +52,7 @@ func (suite *CLIHandlerTestSuite) SetupSuite() {
 	fileService := service.NewFileService()
 
 	// Initialize services
-	suite.unifiedProcessor = transcription.NewUnifiedJobProcessor(jobRepo)
+	suite.unifiedProcessor = transcription.NewUnifiedJobProcessor(jobRepo, suite.helper.Config.TempDir, suite.helper.Config.TranscriptsDir)
 	var err error
 	suite.quickTranscription, err = transcription.NewQuickTranscriptionService(suite.helper.Config, suite.unifiedProcessor, jobRepo)
 	assert.NoError(suite.T(), err)

--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -78,7 +78,7 @@ func (suite *SecurityTestSuite) SetupSuite() {
 	fileService := service.NewFileService()
 
 	// Initialize services
-	suite.unifiedProcessor = transcription.NewUnifiedJobProcessor(jobRepo)
+	suite.unifiedProcessor = transcription.NewUnifiedJobProcessor(jobRepo, suite.config.TempDir, suite.config.TranscriptsDir)
 	var err error
 	suite.quickTranscriptionService, err = transcription.NewQuickTranscriptionService(suite.config, suite.unifiedProcessor, jobRepo)
 	if err != nil {


### PR DESCRIPTION
- Add TempDir field to Config struct to read TEMP_DIR env var
- Update NewUnifiedTranscriptionService to accept tempDir and outputDir parameters
- Remove hardcoded "data/temp" and "data/transcripts" paths from unified service
- Update NewUnifiedJobProcessor to pass directory paths from config
- Update main.go to use cfg.TempDir and cfg.TranscriptsDir
- Update all test files to use new function signatures
- Fix database.go to use directory from DATABASE_PATH instead of hardcoded "data/"