### PR TITLE
fix: speaker rename now updates in real-time without page reload

### DIFF
--- a/web/frontend/src/features/transcription/components/audio-detail/TranscriptSection.tsx
+++ b/web/frontend/src/features/transcription/components/audio-detail/TranscriptSection.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useMemo } from "react";
 import { createPortal } from "react-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { TranscriptView } from "@/components/transcript/TranscriptView";
 import { useNotes, useCreateNote, useUpdateNote, useDeleteNote } from "@/features/transcription/hooks/useTranscriptionNotes";
 import { useSelectionMenu } from "@/features/transcription/hooks/useSelectionMenu";
@@ -56,6 +57,7 @@ export function TranscriptSection({
 }: TranscriptSectionProps & { className?: string }) {
     const isMobile = useIsMobile();
     const isDesktop = useIsDesktop();
+    const queryClient = useQueryClient();
 
     // Data hooks
     const { data: notes = [] } = useNotes(audioId);
@@ -212,7 +214,9 @@ export function TranscriptSection({
                 onOpenChange={setSpeakerRenameOpen}
                 transcriptionId={audioId}
                 initialSpeakers={getDetectedSpeakers()}
-                onSpeakerMappingsUpdate={() => { }}
+                onSpeakerMappingsUpdate={() => {
+                    queryClient.invalidateQueries({ queryKey: ["speakerMappings", audioId] });
+                }}
             />
             {/* Portals */}
             {createPortal(


### PR DESCRIPTION
After renaming speakers in Timeline View, the changes now appear immediately in both the transcript display and downloads (JSON, TXT, SRT).

Root cause: The onSpeakerMappingsUpdate callback was a no-op, so the React Query cache wasn't being invalidated after saving speaker mappings.

Fix: Invalidate the speakerMappings cache when the dialog saves, triggering an automatic refetch that updates all components using the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)