### PR TITLE
fix: Listen button in selection menu now works in Timeline View

### DIFF
--- a/web/frontend/src/components/transcript/TranscriptView.tsx
+++ b/web/frontend/src/components/transcript/TranscriptView.tsx
@@ -246,6 +246,7 @@ export const TranscriptView = forwardRef<HTMLDivElement, TranscriptViewProps>(({
                     // Ensure text is the selection target, not the container
                     WebkitTouchCallout: 'default'
                 }}
+                data-transcript-text
             >
                 {/* The hook returns the built text string, so we just render it directly */}
                 {fullText}
@@ -296,6 +297,7 @@ export const TranscriptView = forwardRef<HTMLDivElement, TranscriptViewProps>(({
                                 touchAction: 'pan-y pinch-zoom',
                                 WebkitTouchCallout: 'default'
                             }}
+                            data-transcript-text
                         >
                             {segment.fullText || segment.text}
                         </div>

--- a/web/frontend/src/features/transcription/hooks/useSelectionMenu.ts
+++ b/web/frontend/src/features/transcription/hooks/useSelectionMenu.ts
@@ -86,10 +86,17 @@ export function useSelectionMenu(
             }
 
             // Calculate absolute character index using TreeWalker
+            // Only count text nodes inside elements marked with data-transcript-text
+            // This prevents timestamps and speaker names from throwing off the character index
             const walker = document.createTreeWalker(
                 containerRef.current,
                 NodeFilter.SHOW_TEXT,
-                null
+                {
+                    acceptNode: (node) => {
+                        const parent = node.parentElement?.closest('[data-transcript-text]');
+                        return parent ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+                    }
+                }
             );
 
             let charIndex = 0;


### PR DESCRIPTION
The selection menu's "Listen" button wasn't working in Timeline View because the character-to-timestamp mapping was incorrectly counting text from timestamp and speaker name elements.

Changes:
- Add data-transcript-text attribute to transcript text containers
- Update TreeWalker in useSelectionMenu to only count text inside these marked elements

This fixes the character index calculation so word timestamps are correctly looked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)