### PR TITLE
feat: add VAD segmentation thresholds for Pyannote diarization

### DIFF
--- a/internal/transcription/adapters/pyannote_adapter.go
+++ b/internal/transcription/adapters/pyannote_adapter.go
@@ -393,6 +393,14 @@ func (p *PyAnnoteAdapter) buildPyAnnoteArgs(input interfaces.AudioInput, params 
 	// Add output format
 	args = append(args, "--output-format", outputFormat)
 
+	// Add segmentation thresholds if provided
+	if onset := p.GetFloatParameter(params, "segmentation_onset"); onset > 0 {
+		args = append(args, "--segmentation-onset", fmt.Sprintf("%.3f", onset))
+	}
+	if offset := p.GetFloatParameter(params, "segmentation_offset"); offset > 0 {
+		args = append(args, "--segmentation-offset", fmt.Sprintf("%.3f", offset))
+	}
+
 	// Device is handled automatically by the script
 
 	return args, nil

--- a/internal/transcription/unified_service.go
+++ b/internal/transcription/unified_service.go
@@ -725,6 +725,15 @@ func (u *UnifiedTranscriptionService) convertToPyannoteParams(params models.Whis
 		paramMap["hf_token"] = *params.HfToken
 	}
 
+	// Map VAD thresholds to Pyannote segmentation parameters
+	// These control voice activity detection sensitivity for diarization
+	if params.VadOnset > 0 {
+		paramMap["segmentation_onset"] = params.VadOnset
+	}
+	if params.VadOffset > 0 {
+		paramMap["segmentation_offset"] = params.VadOffset
+	}
+
 	return paramMap
 }
 

--- a/web/frontend/src/components/transcription/TranscriptionConfigDialog.tsx
+++ b/web/frontend/src/components/transcription/TranscriptionConfigDialog.tsx
@@ -256,6 +256,8 @@ const PARAM_DESCRIPTIONS = {
     vad_method: "Voice detection: Pyannote (accurate) or Silero (fast).",
     initial_prompt: "Context text to guide transcription style.",
     hf_token: "Required for Pyannote diarization models.",
+    vad_onset: "Voice detection sensitivity. Lower values (0.3-0.4) catch quieter/distant speakers.",
+    vad_offset: "Speech ending sensitivity. Lower values detect speech endings more precisely.",
 };
 
 // ============================================================================
@@ -655,6 +657,34 @@ function WhisperConfig({ params, updateParam, isMultiTrack }: ConfigProps) {
                                         className={inputClassName}
                                     />
                                 </FormField>
+
+                                <div className="pt-3 border-t border-[var(--border-subtle)]">
+                                    <p className="text-xs text-[var(--text-tertiary)] mb-3">Voice Detection Tuning (for noisy/distant audio)</p>
+                                    <div className="grid grid-cols-2 gap-4">
+                                        <FormField label="VAD Onset" description={PARAM_DESCRIPTIONS.vad_onset}>
+                                            <Input
+                                                type="number"
+                                                min={0.1}
+                                                max={0.9}
+                                                step={0.05}
+                                                value={params.vad_onset}
+                                                onChange={(e) => updateParam('vad_onset', parseFloat(e.target.value) || 0.5)}
+                                                className={inputClassName}
+                                            />
+                                        </FormField>
+                                        <FormField label="VAD Offset" description={PARAM_DESCRIPTIONS.vad_offset}>
+                                            <Input
+                                                type="number"
+                                                min={0.1}
+                                                max={0.9}
+                                                step={0.05}
+                                                value={params.vad_offset}
+                                                onChange={(e) => updateParam('vad_offset', parseFloat(e.target.value) || 0.363)}
+                                                className={inputClassName}
+                                            />
+                                        </FormField>
+                                    </div>
+                                </div>
                             </div>
                         )}
                     </div>
@@ -868,15 +898,45 @@ function ParakeetConfig({ params, updateParam, isMultiTrack }: ConfigProps) {
                                 </div>
 
                                 {params.diarize_model === "pyannote" && (
-                                    <FormField label="Hugging Face Token">
-                                        <Input
-                                            type="password"
-                                            placeholder="hf_..."
-                                            value={params.hf_token || ""}
-                                            onChange={(e) => updateParam('hf_token', e.target.value || undefined)}
-                                            className={inputClassName}
-                                        />
-                                    </FormField>
+                                    <>
+                                        <FormField label="Hugging Face Token">
+                                            <Input
+                                                type="password"
+                                                placeholder="hf_..."
+                                                value={params.hf_token || ""}
+                                                onChange={(e) => updateParam('hf_token', e.target.value || undefined)}
+                                                className={inputClassName}
+                                            />
+                                        </FormField>
+
+                                        <div className="pt-3 border-t border-[var(--border-subtle)]">
+                                            <p className="text-xs text-[var(--text-tertiary)] mb-3">Voice Detection Tuning (for noisy/distant audio)</p>
+                                            <div className="grid grid-cols-2 gap-4">
+                                                <FormField label="VAD Onset" description={PARAM_DESCRIPTIONS.vad_onset}>
+                                                    <Input
+                                                        type="number"
+                                                        min={0.1}
+                                                        max={0.9}
+                                                        step={0.05}
+                                                        value={params.vad_onset}
+                                                        onChange={(e) => updateParam('vad_onset', parseFloat(e.target.value) || 0.5)}
+                                                        className={inputClassName}
+                                                    />
+                                                </FormField>
+                                                <FormField label="VAD Offset" description={PARAM_DESCRIPTIONS.vad_offset}>
+                                                    <Input
+                                                        type="number"
+                                                        min={0.1}
+                                                        max={0.9}
+                                                        step={0.05}
+                                                        value={params.vad_offset}
+                                                        onChange={(e) => updateParam('vad_offset', parseFloat(e.target.value) || 0.363)}
+                                                        className={inputClassName}
+                                                    />
+                                                </FormField>
+                                            </div>
+                                        </div>
+                                    </>
                                 )}
                             </div>
                         )}
@@ -960,15 +1020,45 @@ function CanaryConfig({ params, updateParam, isMultiTrack }: ConfigProps) {
                                 </div>
 
                                 {params.diarize_model === "pyannote" && (
-                                    <FormField label="Hugging Face Token">
-                                        <Input
-                                            type="password"
-                                            placeholder="hf_..."
-                                            value={params.hf_token || ""}
-                                            onChange={(e) => updateParam('hf_token', e.target.value || undefined)}
-                                            className={inputClassName}
-                                        />
-                                    </FormField>
+                                    <>
+                                        <FormField label="Hugging Face Token">
+                                            <Input
+                                                type="password"
+                                                placeholder="hf_..."
+                                                value={params.hf_token || ""}
+                                                onChange={(e) => updateParam('hf_token', e.target.value || undefined)}
+                                                className={inputClassName}
+                                            />
+                                        </FormField>
+
+                                        <div className="pt-3 border-t border-[var(--border-subtle)]">
+                                            <p className="text-xs text-[var(--text-tertiary)] mb-3">Voice Detection Tuning (for noisy/distant audio)</p>
+                                            <div className="grid grid-cols-2 gap-4">
+                                                <FormField label="VAD Onset" description={PARAM_DESCRIPTIONS.vad_onset}>
+                                                    <Input
+                                                        type="number"
+                                                        min={0.1}
+                                                        max={0.9}
+                                                        step={0.05}
+                                                        value={params.vad_onset}
+                                                        onChange={(e) => updateParam('vad_onset', parseFloat(e.target.value) || 0.5)}
+                                                        className={inputClassName}
+                                                    />
+                                                </FormField>
+                                                <FormField label="VAD Offset" description={PARAM_DESCRIPTIONS.vad_offset}>
+                                                    <Input
+                                                        type="number"
+                                                        min={0.1}
+                                                        max={0.9}
+                                                        step={0.05}
+                                                        value={params.vad_offset}
+                                                        onChange={(e) => updateParam('vad_offset', parseFloat(e.target.value) || 0.363)}
+                                                        className={inputClassName}
+                                                    />
+                                                </FormField>
+                                            </div>
+                                        </div>
+                                    </>
                                 )}
                             </div>
                         )}


### PR DESCRIPTION
Add configurable voice activity detection thresholds to improve speaker diarization accuracy for noisy or distant audio recordings.

- Add --segmentation-onset and --segmentation-offset CLI args to pyannote_diarize.py
- Pass segmentation thresholds from Go adapter to Python script
- Map existing vad_onset/vad_offset params to Pyannote segmentation
- Add VAD Onset/Offset inputs to UI when Pyannote diarization is selected (Whisper, Parakeet, Canary model families)

Lower onset values (0.3-0.4) help detect quieter/distant speakers. Lower offset values improve detection of speech endings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)