### PR TITLE
feat: add Docker image publishing workflow for all variants

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,101 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g., v1.0.0, latest, dev)'
+        required: false
+        default: 'dev'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # CPU-only image (no GPU required)
+          - dockerfile: Dockerfile
+            image_name: scriberr
+            description: "Scriberr CPU-only (no GPU required)"
+          # CUDA image for GTX 10-series through RTX 40-series
+          - dockerfile: Dockerfile.cuda
+            image_name: scriberr-cuda
+            description: "Scriberr with CUDA 12.6 support (GTX 10-series through RTX 40-series)"
+          # Blackwell CUDA image for RTX 50-series
+          - dockerfile: Dockerfile.cuda.12.9
+            image_name: scriberr-cuda-blackwell
+            description: "Scriberr with CUDA 12.9 support (RTX 50-series Blackwell)"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }}
+          tags: |
+            # Tag with version for releases (v1.0.0 -> 1.0.0)
+            type=semver,pattern={{version}}
+            # Tag with major.minor for releases (v1.0.0 -> 1.0)
+            type=semver,pattern={{major}}.{{minor}}
+            # Tag with 'latest' for releases
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            # Tag with 'dev' for main branch pushes
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            # Tag with manual input if workflow_dispatch
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            # Tag with short SHA
+            type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=${{ matrix.image_name }}
+            org.opencontainers.image.description=${{ matrix.description }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Output image info
+        run: |
+          echo "### ${{ matrix.image_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "Tags:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   scriberr:
-    image: ghcr.io/rishikanthc/scriberr:v1.0.4-cuda
+    image: ghcr.io/rishikanthc/scriberr-cuda:latest
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
- Add `docker-publish.yml` workflow to publish all 3 Docker image variants to GitHub Container Registry (ghcr.io)
- Update `docker-compose.cuda.yml` to use consistent image naming

## Docker Images Published
| Image | Dockerfile | Target |
|-------|-----------|--------|
| `ghcr.io/rishikanthc/scriberr` | `Dockerfile` | CPU-only |
| `ghcr.io/rishikanthc/scriberr-cuda` | `Dockerfile.cuda` | CUDA 12.6 (GTX 10-series through RTX 40-series) |
| `ghcr.io/rishikanthc/scriberr-cuda-blackwell` | `Dockerfile.cuda.12.9` | CUDA 12.9 (RTX 50-series Blackwell) |

## Workflow Triggers
| Trigger | Tags Applied |
|---------|-------------|
| Version tag `v1.2.3` | `1.2.3`, `1.2`, `latest`, `sha-<commit>` |
| Push to `main` | `dev`, `sha-<commit>` |
| PR to `main` | Build only (no push) |
| Manual dispatch | Custom tag input |

## Test plan
- [ ] Verify workflow syntax is valid in GitHub Actions
- [ ] Merge to main and confirm images are built and pushed to ghcr.io
- [ ] Test pulling images: `docker pull ghcr.io/rishikanthc/scriberr:dev`

🤖 Generated with [Claude Code](https://claude.ai/code)