### PR TITLE
add pipeline status endpoint and expose in UI

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -135,6 +135,7 @@ func SetupRoutes(handler *Handler, authService *auth.AuthService) *gin.Engine {
 			transcription.POST("/:id/kill", handler.KillJob)
 			transcription.GET("/:id/logs", handler.GetJobLogs)
 			transcription.GET("/:id/status", handler.GetJobStatus)
+			transcription.GET("/:id/pipeline-status", handler.GetPipelineStatus)
 			transcription.GET("/:id/transcript", handler.GetTranscript)
 			transcription.GET("/:id/execution", handler.GetJobExecutionData)
 			transcription.GET("/:id/merge-status", handler.GetMergeStatus)

--- a/internal/models/transcription.go
+++ b/internal/models/transcription.go
@@ -46,6 +46,20 @@ const (
 	StatusFailed     JobStatus = "failed"
 )
 
+// PipelineStage represents fine-grained pipeline progress for a job execution.
+type PipelineStage string
+
+const (
+	StageQueued        PipelineStage = "queued"
+	StagePreprocessing PipelineStage = "preprocessing"
+	StageTranscribing  PipelineStage = "transcribing"
+	StageDiarizing     PipelineStage = "diarizing"
+	StageMerging       PipelineStage = "merging"
+	StagePersisting    PipelineStage = "persisting"
+	StageCompleted     PipelineStage = "completed"
+	StageFailed        PipelineStage = "failed"
+)
+
 // WhisperXParams contains parameters for WhisperX transcription
 type WhisperXParams struct {
 	// Model family (whisper or nvidia)
@@ -312,8 +326,12 @@ type TranscriptionJobExecution struct {
 	ActualParameters WhisperXParams `json:"actual_parameters" gorm:"embedded;embeddedPrefix:actual_"`
 
 	// Execution results
-	Status       JobStatus `json:"status" gorm:"type:varchar(20);not null"`
-	ErrorMessage *string   `json:"error_message,omitempty" gorm:"type:text"`
+	Status            JobStatus     `json:"status" gorm:"type:varchar(20);not null"`
+	ErrorMessage      *string       `json:"error_message,omitempty" gorm:"type:text"`
+	PipelineStage     PipelineStage `json:"pipeline_stage" gorm:"type:varchar(32);default:'queued'"`
+	PipelineProgress  float64       `json:"pipeline_progress" gorm:"type:real;default:0"`
+	PipelineMessage   *string       `json:"pipeline_message,omitempty" gorm:"type:text"`
+	PipelineUpdatedAt *time.Time    `json:"pipeline_updated_at,omitempty" gorm:"type:datetime"`
 
 	// Metadata
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`

--- a/internal/transcription/adapters_test.go
+++ b/internal/transcription/adapters_test.go
@@ -97,6 +97,14 @@ func (m *MockJobRepository) FindActiveTrackJobs(ctx context.Context, parentJobID
 	return args.Get(0).([]models.TranscriptionJob), args.Error(1)
 }
 
+func (m *MockJobRepository) FindLatestExecution(ctx context.Context, jobID string) (*models.TranscriptionJobExecution, error) {
+	args := m.Called(ctx, jobID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.TranscriptionJobExecution), args.Error(1)
+}
+
 func (m *MockJobRepository) FindLatestCompletedExecution(ctx context.Context, jobID string) (*models.TranscriptionJobExecution, error) {
 	args := m.Called(ctx, jobID)
 	if args.Get(0) == nil {

--- a/tests/test_helpers.go
+++ b/tests/test_helpers.go
@@ -344,6 +344,14 @@ func (m *MockJobRepository) FindActiveTrackJobs(ctx context.Context, parentJobID
 	return args.Get(0).([]models.TranscriptionJob), args.Error(1)
 }
 
+func (m *MockJobRepository) FindLatestExecution(ctx context.Context, jobID string) (*models.TranscriptionJobExecution, error) {
+	args := m.Called(ctx, jobID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.TranscriptionJobExecution), args.Error(1)
+}
+
 func (m *MockJobRepository) FindLatestCompletedExecution(ctx context.Context, jobID string) (*models.TranscriptionJobExecution, error) {
 	args := m.Called(ctx, jobID)
 	if args.Get(0) == nil {

--- a/web/frontend/src/features/transcription/components/AudioFilesTable.tsx
+++ b/web/frontend/src/features/transcription/components/AudioFilesTable.tsx
@@ -715,6 +715,41 @@ export const AudioFilesTable = memo(function AudioFilesTable({
 		});
 	}, []);
 
+	const getPipelineLabel = useCallback((stage?: string) => {
+		if (!stage) return undefined;
+		switch (stage) {
+			case "queued":
+				return "Queued";
+			case "preprocessing":
+				return "Preprocessing";
+			case "transcribing":
+				return "Transcribing";
+			case "diarizing":
+				return "Diarizing";
+			case "merging":
+				return "Merging";
+			case "persisting":
+				return "Saving";
+			case "completed":
+				return "Completed";
+			case "failed":
+				return "Failed";
+			default:
+				return undefined;
+		}
+	}, []);
+
+	const getDisplayProgress = useCallback((file: AudioFile) => {
+		if (typeof file.pipeline_progress === "number") {
+			return Math.max(0, Math.min(100, Math.round(file.pipeline_progress)));
+		}
+		const mt = trackProgress[file.id];
+		if (file.is_multi_track && mt?.progress?.percentage != null) {
+			return Math.max(0, Math.min(100, Math.round(mt.progress.percentage)));
+		}
+		return undefined;
+	}, [trackProgress]);
+
 
 
 
@@ -801,7 +836,31 @@ export const AudioFilesTable = memo(function AudioFilesTable({
 											</h4>
 											<div className="flex items-center gap-1.5 mt-1 text-sm text-gray-500">
 												{formatDate(file.created_at)}
+												{(file.status === "processing" || file.status === "pending") && getPipelineLabel(file.pipeline_stage) && (
+													<>
+														<span className="w-1 h-1 rounded-full bg-gray-400" />
+														<span className="text-xs">{getPipelineLabel(file.pipeline_stage)}</span>
+													</>
+												)}
 											</div>
+											{(file.status === "processing" || file.status === "pending") && getDisplayProgress(file) !== undefined && (
+												<div className="mt-1.5 w-36 sm:w-44">
+													<div className="h-1.5 rounded-full bg-gray-200 dark:bg-zinc-700 overflow-hidden">
+														<div
+															className="h-full bg-[#FF6D20] transition-all duration-300"
+															style={{ width: `${getDisplayProgress(file)}%` }}
+														/>
+													</div>
+													<div className="mt-0.5 text-[11px] text-gray-500 tabular-nums">
+														{getDisplayProgress(file)}%
+													</div>
+												</div>
+											)}
+											{(file.status === "processing" || file.status === "pending") && file.pipeline_message && (
+												<div className="mt-1 text-[11px] text-gray-500 truncate max-w-64">
+													{file.pipeline_message}
+												</div>
+											)}
 										</div>
 									</div>
 

--- a/web/frontend/src/features/transcription/hooks/useAudioFiles.ts
+++ b/web/frontend/src/features/transcription/hooks/useAudioFiles.ts
@@ -10,6 +10,9 @@ export interface AudioFile {
     diarization?: boolean;
     is_multi_track?: boolean;
     error_message?: string;
+    pipeline_stage?: string;
+    pipeline_progress?: number;
+    pipeline_message?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     individual_transcripts?: any;
     speakers?: number;

--- a/web/frontend/src/features/transcription/hooks/useTranscriptionEvents.ts
+++ b/web/frontend/src/features/transcription/hooks/useTranscriptionEvents.ts
@@ -7,14 +7,38 @@ interface JobUpdateEvent {
     type: string;
     payload: {
         job_id: string;
-        status: string;
+        status: AudioFile['status'];
         error?: string;
         progress?: number;
     };
 }
 
+type PipelineStage =
+    | 'queued'
+    | 'preprocessing'
+    | 'transcribing'
+    | 'diarizing'
+    | 'merging'
+    | 'persisting'
+    | 'completed'
+    | 'failed';
+
+interface PipelineUpdateEvent {
+    type: string;
+    payload: {
+        job_id: string;
+        execution_id?: string;
+        stage: PipelineStage;
+        progress: number;
+        step_message?: string;
+        error?: string;
+        started_at: string;
+        updated_at: string;
+    };
+}
+
 export const useTranscriptionEvents = (jobId: string | null) => {
-    const { token } = useAuth();
+    const { token, getAuthHeaders } = useAuth();
     const queryClient = useQueryClient();
     const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -29,12 +53,68 @@ export const useTranscriptionEvents = (jobId: string | null) => {
         const abortController = new AbortController();
         abortControllerRef.current = abortController;
 
+        const upsertJobState = (
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            oldData: any,
+            jobID: string,
+            patch: Partial<AudioFile & { pipeline_stage?: string; pipeline_progress?: number; pipeline_message?: string }>
+        ) => {
+            if (!oldData) return oldData;
+
+            if (oldData.pages) {
+                return {
+                    ...oldData,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    pages: oldData.pages.map((page: any) => ({
+                        ...page,
+                        jobs: page.jobs.map((job: AudioFile) =>
+                            job.id === jobID ? { ...job, ...patch } : job
+                        ),
+                    })),
+                };
+            }
+
+            if (oldData.jobs) {
+                return {
+                    ...oldData,
+                    jobs: oldData.jobs.map((job: AudioFile) =>
+                        job.id === jobID ? { ...job, ...patch } : job
+                    ),
+                };
+            }
+
+            return oldData;
+        };
+
+        const hydratePipelineSnapshot = async () => {
+            try {
+                const response = await fetch(`/api/v1/transcription/${jobId}/pipeline-status`, {
+                    headers: getAuthHeaders(),
+                    signal: abortController.signal,
+                });
+
+                if (!response.ok) return;
+                const data = await response.json();
+                if (!data?.available || !data?.status) return;
+
+                queryClient.setQueriesData(
+                    { queryKey: ['audioFiles'] },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (oldData: any) => upsertJobState(oldData, jobId, {
+                        pipeline_stage: data.status.stage,
+                        pipeline_progress: data.status.progress,
+                        pipeline_message: data.status.step_message || undefined,
+                    })
+                );
+            } catch {
+                // Snapshot is best-effort; SSE remains the source of truth.
+            }
+        };
+
         const connect = async () => {
             try {
                 const response = await fetch(`/api/v1/events?job_id=${jobId}`, {
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                    },
+                    headers: getAuthHeaders(),
                     signal: abortController.signal,
                 });
 
@@ -97,58 +177,36 @@ export const useTranscriptionEvents = (jobId: string | null) => {
             if (event.type === 'job_update') {
                 const payload = event.payload as JobUpdateEvent['payload'];
 
-                // Optimistically update the list
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                queryClient.setQueriesData({ queryKey: ['audioFiles'] }, (oldData: any) => {
-                    if (!oldData) return oldData;
+                queryClient.setQueriesData(
+                    { queryKey: ['audioFiles'] },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (oldData: any) => upsertJobState(oldData, payload.job_id, {
+                        status: payload.status,
+                        error_message: payload.error || undefined,
+                    })
+                );
+            }
 
-                    // Handle generic infinite query structure
-                    if (oldData.pages) {
-                        return {
-                            ...oldData,
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            pages: oldData.pages.map((page: any) => ({
-                                ...page,
-                                jobs: page.jobs.map((job: AudioFile) => {
-                                    if (job.id === payload.job_id) {
-                                        return {
-                                            ...job,
-                                            status: payload.status,
-                                            error_message: payload.error || job.error_message,
-                                        };
-                                    }
-                                    return job;
-                                }),
-                            })),
-                        };
-                    }
-
-                    // Handle standard query structure (if used elsewhere)
-                    if (oldData.jobs) {
-                        return {
-                            ...oldData,
-                            jobs: oldData.jobs.map((job: AudioFile) => {
-                                if (job.id === payload.job_id) {
-                                    return {
-                                        ...job,
-                                        status: payload.status,
-                                        error_message: payload.error || job.error_message,
-                                    };
-                                }
-                                return job;
-                            }),
-                        };
-                    }
-
-                    return oldData;
-                });
+            if (event.type === 'pipeline_update') {
+                const payload = event.payload as PipelineUpdateEvent['payload'];
+                queryClient.setQueriesData(
+                    { queryKey: ['audioFiles'] },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (oldData: any) => upsertJobState(oldData, payload.job_id, {
+                        pipeline_stage: payload.stage,
+                        pipeline_progress: payload.progress,
+                        pipeline_message: payload.step_message || undefined,
+                        error_message: payload.error || undefined,
+                    })
+                );
             }
         };
 
+        hydratePipelineSnapshot();
         connect();
 
         return () => {
             abortController.abort();
         };
-    }, [token, queryClient, jobId]);
+    }, [token, queryClient, jobId, getAuthHeaders]);
 };


### PR DESCRIPTION
this feature adds real-time, step-by-step pipeline visibility for transcription jobs.

currently users can see coarse job states like pending, processing, completed, or failed. 

this feature tracks and exposes finer stages such as queued, preprocessing, transcribing, diarizing, merging, and persisting, with progress percentages and status messages.

full disclosure, I used codex to write this, but I did review the code and test it locally in docker. 

if this PR is acceptable I have a few more features I'd like to add, such as retaining the transcript if diarization fails so the transcription doesn't need to happen again