### PR TITLE
Add environment variable for WhisperX threads parameter

### DIFF
--- a/internal/transcription/unified_service.go
+++ b/internal/transcription/unified_service.go
@@ -705,7 +705,7 @@ func (u *UnifiedTranscriptionService) convertToWhisperXParams(params models.Whis
 	}
 	if params.Threads == 0 {
 		//If the variable is default, try to load it from env variable
-		valStr, ok := os.LookupEnv("WHX_THREADS")
+		valStr, ok := os.LookupEnv("WHX_NUM_THREADS")
 		if ok {
 			val, err := strconv.Atoi(valStr)
 			if err == nil && val >= 0 {


### PR DESCRIPTION
Currently there is no way to set number of threads for WhisperX to use. It always uses 4 threads which is the default in case --threads parameter is not passed to WhisperX. While there are OMP_NUM_THREADS and MKL_NUM_THREADS variables to set number of threads for diarization, there is no such variable for WhisperX.

This pull request introduces WHX_NUM_THREADS environment variable to set number of threads for WhisperX if it stays at its default value (0). If at some point user interface supports setting threads explicitly, this setting will take precedence of enviroment variable.