### PR TITLE
fix: pin torchcodec to 0.7.x for compatibility with PyTorch 2.8.x

### DIFF
--- a/internal/transcription/adapters/whisperx_adapter.go
+++ b/internal/transcription/adapters/whisperx_adapter.go
@@ -352,6 +352,10 @@ func (w *WhisperXAdapter) updateWhisperXDependencies(whisperxPath string) error 
 	content := string(data)
 	content = strings.ReplaceAll(content, "ctranslate2<4.5.0", "ctranslate2==4.6.0")
 
+	// torchcodec>=0.6.0 (upstream default) resolves to 0.10.0+ which requires PyTorch 2.9.
+	// Pin to 0.7.x which is compatible with the PyTorch 2.8.x used here.
+	content = strings.ReplaceAll(content, "torchcodec>=0.6.0", "torchcodec~=0.7.0")
+
 	if !strings.Contains(content, "yt-dlp") {
 		content = strings.ReplaceAll(content,
 			`"transformers>=4.48.0",`,


### PR DESCRIPTION
## Summary

- `torchcodec>=0.6.0` (the upstream pyannote-audio default) resolves to 0.10.0+, which requires PyTorch 2.9
- Scriberr installs PyTorch 2.8.x, causing a C++ ABI symbol mismatch (`undefined symbol: _ZN3c1013MessageLogger6streamB5cxx11Ev`) when pyannote tries to load torchcodec at runtime
- Pinning to `~=0.7.0` — the last release compatible with PyTorch 2.8.x — eliminates the warning and restores correct torchcodec loading

## Test plan

- [ ] Fresh Scriberr install sets up WhisperX environment without the torchcodec warning in transcription logs
- [ ] `python -c "from pyannote.audio.core.io import Audio; print('OK')"` returns `OK` with no warnings
- [ ] Transcription completes successfully on a known-good audio file

🤖 Generated with [Claude Code](https://claude.com/claude-code)