### PR TITLE
fix(queue): allow QUEUE_WORKERS env var to override hardcoded worker count

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -84,7 +84,8 @@ func NewTaskQueue(legacyWorkers int, processor JobProcessor, jobRepo repository.
 
 	// Calculate optimal worker counts, fallback to legacy parameter
 	min, max := getOptimalWorkerCount()
-	if legacyWorkers > 0 {
+	// Only use legacy parameter as fallback when QUEUE_WORKERS env var is not set
+	if os.Getenv("QUEUE_WORKERS") == "" && legacyWorkers > 0 {
 		min = legacyWorkers
 		max = legacyWorkers
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -85,6 +85,7 @@ func NewTaskQueue(legacyWorkers int, processor JobProcessor, jobRepo repository.
 	// Calculate optimal worker counts, fallback to legacy parameter
 	min, max := getOptimalWorkerCount()
 	// Only use legacy parameter as fallback when QUEUE_WORKERS env var is not set
+	// TODO: Deprecate `legacyWorkers` and rely on `getOptimalWorkerCount` instead.
 	if os.Getenv("QUEUE_WORKERS") == "" && legacyWorkers > 0 {
 		min = legacyWorkers
 		max = legacyWorkers

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestGetOptimalWorkerCount_DefaultBehavior verifies that without QUEUE_WORKERS,
+// the function returns positive CPU-based defaults with min <= max.
 func TestGetOptimalWorkerCount_DefaultBehavior(t *testing.T) {
 	t.Setenv("QUEUE_WORKERS", "")
 
@@ -16,6 +18,8 @@ func TestGetOptimalWorkerCount_DefaultBehavior(t *testing.T) {
 	assert.LessOrEqual(t, min, max, "min should be <= max")
 }
 
+// TestGetOptimalWorkerCount_RespectsEnvVar verifies that QUEUE_WORKERS env var
+// pins both min and max to the exact value specified.
 func TestGetOptimalWorkerCount_RespectsEnvVar(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -39,6 +43,9 @@ func TestGetOptimalWorkerCount_RespectsEnvVar(t *testing.T) {
 	}
 }
 
+// TestGetOptimalWorkerCount_IgnoresInvalidEnvVar verifies that non-numeric,
+// zero, and negative QUEUE_WORKERS values are ignored, falling back to
+// CPU-based defaults rather than crashing or using bad values.
 func TestGetOptimalWorkerCount_IgnoresInvalidEnvVar(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,46 +1,40 @@
 package queue
 
 import (
-	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetOptimalWorkerCount_DefaultBehavior(t *testing.T) {
-	os.Unsetenv("QUEUE_WORKERS")
+	t.Setenv("QUEUE_WORKERS", "")
 
 	min, max := getOptimalWorkerCount()
 
-	// Without QUEUE_WORKERS, should return CPU-based values (non-zero)
-	if min <= 0 || max <= 0 {
-		t.Errorf("expected positive worker counts, got min=%d, max=%d", min, max)
-	}
-	if min > max {
-		t.Errorf("min (%d) should be <= max (%d)", min, max)
-	}
+	assert.Positive(t, min, "min workers should be positive")
+	assert.Positive(t, max, "max workers should be positive")
+	assert.LessOrEqual(t, min, max, "min should be <= max")
 }
 
 func TestGetOptimalWorkerCount_RespectsEnvVar(t *testing.T) {
 	tests := []struct {
 		name     string
 		envValue string
-		wantMin  int
-		wantMax  int
+		want     int
 	}{
-		{"single worker", "1", 1, 1},
-		{"four workers", "4", 4, 4},
-		{"ten workers", "10", 10, 10},
+		{"single worker", "1", 1},
+		{"four workers", "4", 4},
+		{"ten workers", "10", 10},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("QUEUE_WORKERS", tt.envValue)
-			defer os.Unsetenv("QUEUE_WORKERS")
+			t.Setenv("QUEUE_WORKERS", tt.envValue)
 
 			min, max := getOptimalWorkerCount()
-			if min != tt.wantMin || max != tt.wantMax {
-				t.Errorf("QUEUE_WORKERS=%s: got min=%d, max=%d; want min=%d, max=%d",
-					tt.envValue, min, max, tt.wantMin, tt.wantMax)
-			}
+
+			assert.Equal(t, tt.want, min, "min workers")
+			assert.Equal(t, tt.want, max, "max workers")
 		})
 	}
 }
@@ -57,67 +51,51 @@ func TestGetOptimalWorkerCount_IgnoresInvalidEnvVar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("QUEUE_WORKERS", tt.envValue)
-			defer os.Unsetenv("QUEUE_WORKERS")
+			t.Setenv("QUEUE_WORKERS", tt.envValue)
 
 			min, max := getOptimalWorkerCount()
-			// Should fall back to CPU-based defaults
-			if min <= 0 || max <= 0 {
-				t.Errorf("QUEUE_WORKERS=%s: expected positive defaults, got min=%d, max=%d",
-					tt.envValue, min, max)
-			}
+
+			assert.Positive(t, min, "should fall back to positive CPU-based default")
+			assert.Positive(t, max, "should fall back to positive CPU-based default")
 		})
 	}
 }
 
 // TestNewTaskQueue_DefaultWorkerCount verifies that without QUEUE_WORKERS,
-// the legacy parameter (2) is used as default - preserving existing behavior.
+// the legacy parameter (2) is used as default, preserving existing behavior.
 func TestNewTaskQueue_DefaultWorkerCount(t *testing.T) {
-	os.Unsetenv("QUEUE_WORKERS")
+	t.Setenv("QUEUE_WORKERS", "")
 
 	tq := NewTaskQueue(2, nil, nil)
 	defer tq.cancel()
 
-	if tq.minWorkers != 2 {
-		t.Errorf("without QUEUE_WORKERS, expected minWorkers=2, got %d", tq.minWorkers)
-	}
-	if tq.maxWorkers != 2 {
-		t.Errorf("without QUEUE_WORKERS, expected maxWorkers=2, got %d", tq.maxWorkers)
-	}
+	assert.Equal(t, 2, tq.minWorkers, "default minWorkers should match legacy parameter")
+	assert.Equal(t, 2, tq.maxWorkers, "default maxWorkers should match legacy parameter")
 }
 
 // TestNewTaskQueue_EnvOverridesLegacy verifies that QUEUE_WORKERS takes
 // precedence over the hardcoded legacy parameter.
-// This is the core bug test - currently QUEUE_WORKERS is ignored.
 func TestNewTaskQueue_EnvOverridesLegacy(t *testing.T) {
 	tests := []struct {
 		name          string
 		envValue      string
 		legacyWorkers int
-		wantMin       int
-		wantMax       int
+		want          int
 	}{
-		{"env=1 overrides legacy=2", "1", 2, 1, 1},
-		{"env=4 overrides legacy=2", "4", 2, 4, 4},
-		{"env=3 overrides legacy=2", "3", 2, 3, 3},
+		{"env=1 overrides legacy=2", "1", 2, 1},
+		{"env=4 overrides legacy=2", "4", 2, 4},
+		{"env=3 overrides legacy=2", "3", 2, 3},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("QUEUE_WORKERS", tt.envValue)
-			defer os.Unsetenv("QUEUE_WORKERS")
+			t.Setenv("QUEUE_WORKERS", tt.envValue)
 
 			tq := NewTaskQueue(tt.legacyWorkers, nil, nil)
 			defer tq.cancel()
 
-			if tq.minWorkers != tt.wantMin {
-				t.Errorf("QUEUE_WORKERS=%s with legacy=%d: got minWorkers=%d, want %d",
-					tt.envValue, tt.legacyWorkers, tq.minWorkers, tt.wantMin)
-			}
-			if tq.maxWorkers != tt.wantMax {
-				t.Errorf("QUEUE_WORKERS=%s with legacy=%d: got maxWorkers=%d, want %d",
-					tt.envValue, tt.legacyWorkers, tq.maxWorkers, tt.wantMax)
-			}
+			assert.Equal(t, tt.want, tq.minWorkers, "QUEUE_WORKERS should override legacy minWorkers")
+			assert.Equal(t, tt.want, tq.maxWorkers, "QUEUE_WORKERS should override legacy maxWorkers")
 		})
 	}
 }
@@ -125,13 +103,10 @@ func TestNewTaskQueue_EnvOverridesLegacy(t *testing.T) {
 // TestNewTaskQueue_AutoScaleDisabledWithFixedWorkers verifies that
 // auto-scaling is disabled when QUEUE_WORKERS sets a fixed count.
 func TestNewTaskQueue_AutoScaleDisabledWithFixedWorkers(t *testing.T) {
-	os.Setenv("QUEUE_WORKERS", "3")
-	defer os.Unsetenv("QUEUE_WORKERS")
+	t.Setenv("QUEUE_WORKERS", "3")
 
 	tq := NewTaskQueue(2, nil, nil)
 	defer tq.cancel()
 
-	if tq.autoScale {
-		t.Error("auto-scaling should be disabled when QUEUE_WORKERS sets fixed worker count")
-	}
+	assert.False(t, tq.autoScale, "auto-scaling should be disabled when QUEUE_WORKERS sets fixed count")
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,137 @@
+package queue
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetOptimalWorkerCount_DefaultBehavior(t *testing.T) {
+	os.Unsetenv("QUEUE_WORKERS")
+
+	min, max := getOptimalWorkerCount()
+
+	// Without QUEUE_WORKERS, should return CPU-based values (non-zero)
+	if min <= 0 || max <= 0 {
+		t.Errorf("expected positive worker counts, got min=%d, max=%d", min, max)
+	}
+	if min > max {
+		t.Errorf("min (%d) should be <= max (%d)", min, max)
+	}
+}
+
+func TestGetOptimalWorkerCount_RespectsEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		wantMin  int
+		wantMax  int
+	}{
+		{"single worker", "1", 1, 1},
+		{"four workers", "4", 4, 4},
+		{"ten workers", "10", 10, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("QUEUE_WORKERS", tt.envValue)
+			defer os.Unsetenv("QUEUE_WORKERS")
+
+			min, max := getOptimalWorkerCount()
+			if min != tt.wantMin || max != tt.wantMax {
+				t.Errorf("QUEUE_WORKERS=%s: got min=%d, max=%d; want min=%d, max=%d",
+					tt.envValue, min, max, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestGetOptimalWorkerCount_IgnoresInvalidEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+	}{
+		{"non-numeric", "abc"},
+		{"zero", "0"},
+		{"negative", "-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("QUEUE_WORKERS", tt.envValue)
+			defer os.Unsetenv("QUEUE_WORKERS")
+
+			min, max := getOptimalWorkerCount()
+			// Should fall back to CPU-based defaults
+			if min <= 0 || max <= 0 {
+				t.Errorf("QUEUE_WORKERS=%s: expected positive defaults, got min=%d, max=%d",
+					tt.envValue, min, max)
+			}
+		})
+	}
+}
+
+// TestNewTaskQueue_DefaultWorkerCount verifies that without QUEUE_WORKERS,
+// the legacy parameter (2) is used as default - preserving existing behavior.
+func TestNewTaskQueue_DefaultWorkerCount(t *testing.T) {
+	os.Unsetenv("QUEUE_WORKERS")
+
+	tq := NewTaskQueue(2, nil, nil)
+	defer tq.cancel()
+
+	if tq.minWorkers != 2 {
+		t.Errorf("without QUEUE_WORKERS, expected minWorkers=2, got %d", tq.minWorkers)
+	}
+	if tq.maxWorkers != 2 {
+		t.Errorf("without QUEUE_WORKERS, expected maxWorkers=2, got %d", tq.maxWorkers)
+	}
+}
+
+// TestNewTaskQueue_EnvOverridesLegacy verifies that QUEUE_WORKERS takes
+// precedence over the hardcoded legacy parameter.
+// This is the core bug test - currently QUEUE_WORKERS is ignored.
+func TestNewTaskQueue_EnvOverridesLegacy(t *testing.T) {
+	tests := []struct {
+		name          string
+		envValue      string
+		legacyWorkers int
+		wantMin       int
+		wantMax       int
+	}{
+		{"env=1 overrides legacy=2", "1", 2, 1, 1},
+		{"env=4 overrides legacy=2", "4", 2, 4, 4},
+		{"env=3 overrides legacy=2", "3", 2, 3, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("QUEUE_WORKERS", tt.envValue)
+			defer os.Unsetenv("QUEUE_WORKERS")
+
+			tq := NewTaskQueue(tt.legacyWorkers, nil, nil)
+			defer tq.cancel()
+
+			if tq.minWorkers != tt.wantMin {
+				t.Errorf("QUEUE_WORKERS=%s with legacy=%d: got minWorkers=%d, want %d",
+					tt.envValue, tt.legacyWorkers, tq.minWorkers, tt.wantMin)
+			}
+			if tq.maxWorkers != tt.wantMax {
+				t.Errorf("QUEUE_WORKERS=%s with legacy=%d: got maxWorkers=%d, want %d",
+					tt.envValue, tt.legacyWorkers, tq.maxWorkers, tt.wantMax)
+			}
+		})
+	}
+}
+
+// TestNewTaskQueue_AutoScaleDisabledWithFixedWorkers verifies that
+// auto-scaling is disabled when QUEUE_WORKERS sets a fixed count.
+func TestNewTaskQueue_AutoScaleDisabledWithFixedWorkers(t *testing.T) {
+	os.Setenv("QUEUE_WORKERS", "3")
+	defer os.Unsetenv("QUEUE_WORKERS")
+
+	tq := NewTaskQueue(2, nil, nil)
+	defer tq.cancel()
+
+	if tq.autoScale {
+		t.Error("auto-scaling should be disabled when QUEUE_WORKERS sets fixed worker count")
+	}
+}


### PR DESCRIPTION
## Summary

The `QUEUE_WORKERS` env var is supposed to control how many queue workers get created. This is handled by `internal/queue/queue.go:getOptimalWorkerCount` which checks:

```go
	// Check for environment variable override
	if workerStr := os.Getenv("QUEUE_WORKERS"); workerStr != "" {
		if workers, err := strconv.Atoi(workerStr); err == nil && workers > 0 {
			return workers, workers // Fixed worker count
		}
	}
```

However, when this value gets used, it's overwritten by a legacy workers argument without checking if the env var was set in `internal/queue/queue.go:NewTaskQueue`:

```go
	min, max := getOptimalWorkerCount()
	if legacyWorkers > 0 {
		min = legacyWorkers
		max = legacyWorkers
	}
```

Since `NewTaskQueue` is called unconditionally with `legacyWorkers = 2` (see `main.go:130`):

```go
	taskQueue := queue.NewTaskQueue(2, unifiedProcessor, jobRepo) // 2 workers
```

this means that QUEUE_WORKERS is always ignored.

The right solution would seem to be to remove the `legacyWorkers` argument entirely, since the behavior of selecting worker pool size ranges and auto-scaling is now handled in `getOptimalWorkerCount()` instead of in `main.go`. However, the fact that this seemingly-simple refactor wasn't done when `getOptimalWorkerCount` was first added suggests that it's not as simple as it seems, and as a new contributor, I'll err on the side of caution. As such, this PR only proposes ignoring `legacyWorkers` when `QUEUE_WORKERS` is explicitly set. I've left a TODO comment recommending that `legacyWorkers` be properly deprecated and removed when practical.

This development followed TDD. Tests were verified to fail before changes and work after them.

Fixes #379

Fixes #417

Fixes #428

Disclaimer: Used Claude Code to find bug and implement changes. All code and comments are fully manually reviewed.