### PR TITLE
feat(docker): add OCI image provenance labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,32 @@ RUN mkdir -p /out/bin/cli \
 ########################
 FROM python:3.11-slim AS runtime
 
+# OCI image annotations — set at build time for provenance (OCI image spec).
+# Example:
+#   docker build \
+#     --build-arg VCS_REF="$(git rev-parse HEAD)" \
+#     --build-arg BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+#     --build-arg VERSION="$(git describe --tags --always)" \
+#     -f Dockerfile .
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+ARG VERSION=unknown
+ARG OCI_SOURCE=https://github.com/rishikanthc/Scriberr.git
+ARG OCI_URL=https://github.com/rishikanthc/Scriberr
+ARG OCI_DOCUMENTATION=https://github.com/rishikanthc/Scriberr/blob/main/README.md
+ARG OCI_LICENSES=MIT
+ARG OCI_TITLE=Scriberr
+ARG OCI_DESCRIPTION=Self-hosted audio transcription with WhisperX, web UI, and REST API. CPU runtime image.
+LABEL org.opencontainers.image.title="${OCI_TITLE}" \
+      org.opencontainers.image.description="${OCI_DESCRIPTION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="${OCI_SOURCE}" \
+      org.opencontainers.image.url="${OCI_URL}" \
+      org.opencontainers.image.documentation="${OCI_DOCUMENTATION}" \
+      org.opencontainers.image.licenses="${OCI_LICENSES}"
+
 ENV PYTHONUNBUFFERED=1 \
   HOST=0.0.0.0 \
   PORT=8080 \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -49,6 +49,26 @@ RUN mkdir -p /out/bin/cli \
 ########################
 FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04 AS runtime
 
+# OCI image annotations — same build-args as the root Dockerfile; set in release CI.
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+ARG VERSION=unknown
+ARG OCI_SOURCE=https://github.com/rishikanthc/Scriberr.git
+ARG OCI_URL=https://github.com/rishikanthc/Scriberr
+ARG OCI_DOCUMENTATION=https://github.com/rishikanthc/Scriberr/blob/main/README.md
+ARG OCI_LICENSES=MIT
+ARG OCI_TITLE=Scriberr
+ARG OCI_DESCRIPTION=Self-hosted audio transcription with WhisperX, web UI, and REST API. NVIDIA CUDA 12.6 runtime image.
+LABEL org.opencontainers.image.title="${OCI_TITLE}" \
+      org.opencontainers.image.description="${OCI_DESCRIPTION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="${OCI_SOURCE}" \
+      org.opencontainers.image.url="${OCI_URL}" \
+      org.opencontainers.image.documentation="${OCI_DOCUMENTATION}" \
+      org.opencontainers.image.licenses="${OCI_LICENSES}"
+
 ENV PYTHONUNBUFFERED=1 \
   HOST=0.0.0.0 \
   PORT=8080 \

--- a/Dockerfile.cuda.12.9
+++ b/Dockerfile.cuda.12.9
@@ -51,6 +51,26 @@ RUN mkdir -p /out/bin/cli \
 ########################
 FROM nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04 AS runtime
 
+# OCI image annotations — CUDA 12.9 / Blackwell; same build-args as Dockerfile.cuda.
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+ARG VERSION=unknown
+ARG OCI_SOURCE=https://github.com/rishikanthc/Scriberr.git
+ARG OCI_URL=https://github.com/rishikanthc/Scriberr
+ARG OCI_DOCUMENTATION=https://github.com/rishikanthc/Scriberr/blob/main/README.md
+ARG OCI_LICENSES=MIT
+ARG OCI_TITLE=Scriberr
+ARG OCI_DESCRIPTION=Self-hosted audio transcription with WhisperX, web UI, and REST API. NVIDIA CUDA 12.9 runtime image for Blackwell GPUs.
+LABEL org.opencontainers.image.title="${OCI_TITLE}" \
+      org.opencontainers.image.description="${OCI_DESCRIPTION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="${OCI_SOURCE}" \
+      org.opencontainers.image.url="${OCI_URL}" \
+      org.opencontainers.image.documentation="${OCI_DOCUMENTATION}" \
+      org.opencontainers.image.licenses="${OCI_LICENSES}"
+
 ENV PYTHONUNBUFFERED=1 \
     HOST=0.0.0.0 \
     PORT=8080 \


### PR DESCRIPTION
## Summary

Adds [OpenContainers image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md) on the final stage of the CPU, CUDA 12.6, and CUDA 12.9 Dockerfiles so released images can be tied to git revision, version, build time, and documentation.

## Changes

- **`Dockerfile`** — OCI `LABEL` block with build-args (`VCS_REF`, `BUILD_DATE`, `VERSION`, `OCI_*`).
- **`Dockerfile.cuda`** / **`Dockerfile.cuda.12.9`** — same pattern on the CUDA runtime stages; descriptions note the CUDA variant.

Defaults assume this repo’s canonical GitHub URLs on `main`. Optional `OCI_SOURCE`, `OCI_URL`, and `OCI_DOCUMENTATION` remain available when an image must advertise different canonical URLs.

## CI / releases

Official pipelines should pass `VCS_REF` (full SHA), `BUILD_DATE` (RFC 3339 UTC), and `VERSION` (tag or `git describe`) so labels reflect the real build.

Adds #452 