### PR TITLE
fix: resolve UID 1000 conflict with ubuntu 24.04 user in CUDA base images - Working GPU transcription on Blackwell

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -94,9 +94,13 @@ RUN curl -fsSL https://deno.land/install.sh | sh \
   && deno --version
 
 # Create default user (will be modified at runtime if needed)
-# Use 10001 to avoid conflicts with existing users in CUDA base image
-RUN groupadd -g 10001 appuser \
-  && useradd -m -u 10001 -g 10001 appuser \
+# Previously used 10001 to avoid conflicts with existing user in CUDA base image
+# Ubuntu 24.04 ships with a default 'ubuntu' user at UID/GID 1000, causing permission conflicts with default appuser account.
+# Remove it first, then create appuser at UID 1000 to match the entrypoint script.
+RUN userdel -r ubuntu 2>/dev/null || true \
+  && groupdel ubuntu 2>/dev/null || true \
+  && groupadd -g 1000 appuser \
+  && useradd -m -u 1000 -g 1000 appuser \
   && mkdir -p /app/data/uploads /app/data/transcripts \
   && chown -R appuser:appuser /app
 

--- a/Dockerfile.cuda.12.9
+++ b/Dockerfile.cuda.12.9
@@ -96,9 +96,13 @@ RUN curl -fsSL https://deno.land/install.sh | sh \
   && deno --version
 
 # Create default user (will be modified at runtime if needed)
-# Use 10001 to avoid conflicts with existing users in CUDA base image
-RUN groupadd -g 10001 appuser \
-  && useradd -m -u 10001 -g 10001 appuser \
+# Previously used 10001 to avoid conflicts with existing user in CUDA base image
+# Ubuntu 24.04 ships with a default 'ubuntu' user at UID/GID 1000, causing permission conflicts with default appuser account.
+# Remove it first, then create appuser at UID 1000 to match the entrypoint script.
+RUN userdel -r ubuntu 2>/dev/null || true \
+  && groupdel ubuntu 2>/dev/null || true \
+  && groupadd -g 1000 appuser \
+  && useradd -m -u 1000 -g 1000 appuser \
   && mkdir -p /app/data/uploads /app/data/transcripts \
   && chown -R appuser:appuser /app
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Scriberr is an open-source, and completely offline audio transcription applicati
   <img src="screenshots/hero.png" alt="Scriberr Desktop App" width="800" />
 </div>
 
+
+## Why this fork?
+Hi everyone, this is a simple fork of Scriberr put together to make some simple dockerfile fixes to resolve UID permission conflicts in the CUDA 12.9 version of the image. At present, the current build with CUDA 12.9 on blackwell gpus errors out due to these permission conflicts, I can confirm that my version here is tested and confirmed to work on an RTX 5090 system. I have no intentions of maintaining this package, this was a one off contribution as I know that others may benefit. I have accordingly committed these changes to the original developer so that they can update the original repository accordingly and all can benefit :)
+
 ## Update on project status
 Hi everyone,
 It’s been a while since the last update, so I wanted to share what’s been going on with Scriberr.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Scriberr is an open-source, and completely offline audio transcription applicati
 
 
 ## Why this fork?
-Hi everyone, this is a simple fork of Scriberr put together to make some simple dockerfile fixes to resolve UID permission conflicts in the CUDA 12.9 version of the image. At present, the current build with CUDA 12.9 on blackwell gpus errors out due to these permission conflicts, I can confirm that my version here is tested and confirmed to work on an RTX 5090 system. I have no intentions of maintaining this package, this was a one off contribution as I know that others may benefit. I have accordingly committed these changes to the original developer so that they can update the original repository accordingly and all can benefit :)
+Hi everyone, this is a simple fork of Scriberr put together to make some simple dockerfile fixes to resolve UID permission conflicts in the CUDA 12.9 version of the image. At present, the current build with CUDA 12.9 on blackwell gpus errors out due to these permission conflicts, I can confirm that my version here is tested and confirmed to work on an RTX 5090 system. I have no intentions of maintaining this package, this was a one off contribution. I have accordingly committed these changes to the original developer so that they can update the original repository and all can benefit :)
 
 ## Update on project status
 Hi everyone,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Scriberr is an open-source, and completely offline audio transcription applicati
 
 
 ## Why this fork?
-Hi everyone, this is a simple fork of Scriberr put together to make some simple dockerfile fixes to resolve UID permission conflicts in the CUDA 12.9 version of the image. At present, the current build with CUDA 12.9 on blackwell gpus errors out due to these permission conflicts, I can confirm that my version here is tested and confirmed to work on an RTX 5090 system. I have no intentions of maintaining this package, this was a one off contribution. I have accordingly committed these changes to the original developer so that they can update the original repository and all can benefit :)
+Hi everyone, this is a simple fork of Scriberr put together to make some simple dockerfile fixes to resolve UID permission conflicts in the CUDA 12.9 version of the image. At present, the current build with CUDA 12.9 on blackwell gpus errors out due to these permission conflicts, I can confirm that my version here is tested and working on an RTX 5090 system. I have no intentions of maintaining this package, this was a one off contribution. I have accordingly committed these changes to the original developer so that they can update the original repository and all can benefit :)
 
 ## Update on project status
 Hi everyone,


### PR DESCRIPTION
## Problem
Ubuntu 24.04 ships with a default `ubuntu` user at UID/GID 1000. Both CUDA Dockerfiles create `appuser` at UID 10001 to avoid this conflict, but the `docker-entrypoint.sh` script uses PUID/PGID 1000 by default, causing a mismatch that results in persistent permission errors on volume mounts. This leads to cascading errors on blackwell systems.

## Fix
Remove the default `ubuntu` user at UID 1000 before creating `appuser` at UID 1000, consistent with what the entrypoint script expects.

## Files changed
- `Dockerfile.cuda`
- `Dockerfile.cuda.12.9`

## Tested and confirmed working on
- Latest main branch (Commit bdb8838), image built locally on Windows 11, Docker Desktop (WSL2), RTX 5090 (Blackwell)