### PR TITLE
feat: add automatic transcription summaries

### DIFF
--- a/api-docs/docs.go
+++ b/api-docs/docs.go
@@ -1950,6 +1950,15 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4334,20 +4343,28 @@ const docTemplate = `{
         },
         "api.SummarySettingsRequest": {
             "type": "object",
-            "required": [
-                "default_model"
-            ],
             "properties": {
+                "auto_summarize": {
+                    "type": "boolean"
+                },
                 "default_model": {
-                    "type": "string",
-                    "minLength": 1
+                    "type": "string"
+                },
+                "default_template_id": {
+                    "type": "string"
                 }
             }
         },
         "api.SummarySettingsResponse": {
             "type": "object",
             "properties": {
+                "auto_summarize": {
+                    "type": "boolean"
+                },
                 "default_model": {
+                    "type": "string"
+                },
+                "default_template_id": {
                     "type": "string"
                 }
             }

--- a/api-docs/swagger.json
+++ b/api-docs/swagger.json
@@ -1944,6 +1944,15 @@
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4328,20 +4337,28 @@
         },
         "api.SummarySettingsRequest": {
             "type": "object",
-            "required": [
-                "default_model"
-            ],
             "properties": {
+                "auto_summarize": {
+                    "type": "boolean"
+                },
                 "default_model": {
-                    "type": "string",
-                    "minLength": 1
+                    "type": "string"
+                },
+                "default_template_id": {
+                    "type": "string"
                 }
             }
         },
         "api.SummarySettingsResponse": {
             "type": "object",
             "properties": {
+                "auto_summarize": {
+                    "type": "boolean"
+                },
                 "default_model": {
+                    "type": "string"
+                },
+                "default_template_id": {
                     "type": "string"
                 }
             }

--- a/api-docs/swagger.yaml
+++ b/api-docs/swagger.yaml
@@ -343,15 +343,20 @@ definitions:
     type: object
   api.SummarySettingsRequest:
     properties:
+      auto_summarize:
+        type: boolean
       default_model:
-        minLength: 1
         type: string
-    required:
-    - default_model
+      default_template_id:
+        type: string
     type: object
   api.SummarySettingsResponse:
     properties:
+      auto_summarize:
+        type: boolean
       default_model:
+        type: string
+      default_template_id:
         type: string
     type: object
   api.SummaryTemplateRequest:
@@ -1853,6 +1858,12 @@ paths:
           description: No Content
           schema:
             type: string
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Internal Server Error
           schema:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"scriberr/internal/api"
+	"scriberr/internal/autosummary"
 	"scriberr/internal/auth"
 	"scriberr/internal/config"
 	"scriberr/internal/database"
@@ -117,6 +118,8 @@ func main() {
 	// Initialize unified transcription processor
 	logger.Startup("transcription", "Initializing transcription service")
 	unifiedProcessor := transcription.NewUnifiedJobProcessor(jobRepo, cfg.TempDir, cfg.TranscriptsDir)
+	autoSummaryService := autosummary.NewService(jobRepo, summaryRepo, llmConfigRepo)
+	unifiedProcessor.GetUnifiedService().SetAutoSummaryService(autoSummaryService)
 	unifiedProcessor.GetUnifiedService().SetBroadcaster(broadcaster)
 
 	// Bootstrap embedded Python environment (for all adapters)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"scriberr/internal/api"
-	"scriberr/internal/autosummary"
 	"scriberr/internal/auth"
+	"scriberr/internal/autosummary"
 	"scriberr/internal/config"
 	"scriberr/internal/database"
 	"scriberr/internal/processing"
@@ -118,7 +118,7 @@ func main() {
 	// Initialize unified transcription processor
 	logger.Startup("transcription", "Initializing transcription service")
 	unifiedProcessor := transcription.NewUnifiedJobProcessor(jobRepo, cfg.TempDir, cfg.TranscriptsDir)
-	autoSummaryService := autosummary.NewService(jobRepo, summaryRepo, llmConfigRepo)
+	autoSummaryService := autosummary.NewService(jobRepo, summaryRepo, llmConfigRepo, speakerMappingRepo)
 	unifiedProcessor.GetUnifiedService().SetAutoSummaryService(autoSummaryService)
 	unifiedProcessor.GetUnifiedService().SetBroadcaster(broadcaster)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,20 @@
 services:
   scriberr:
-    build: .
-    container_name: scriberr
-    environment:
-      - PUID=${UID:-1024}
-      - PGID=${GID:-100}
-      - APP_ENV=${APP_ENV:-production}
-      - TZ=${TZ:-America/New_York}
-      # Set ALLOWED_ORIGINS to the HTTPS URL used for Scriberr if needed.
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
-      # Only set this to false when accessing Scriberr directly over plain HTTP.
-      - HF_TOKEN=${HF_TOKEN:-token_here}
-      - SECURE_COOKIES=${SECURE_COOKIES:-true}
-    volumes:
-      - ${DIR_RECORDINGS}:/voice_recordings
-      - ${DIR_DATA}/app_data:/app/data
-      - ${DIR_DATA}/whisperx-env:/app/whisperx-env
+    image: ghcr.io/rishikanthc/scriberr:latest
     ports:
-      - ${PORT:-8080}:8080
-    networks:
-      - services
-    restart: unless-stopped
-
-  scriberr-sidecarr:
-    image: docker.io/jordanmarchetto/scriberr-sidecarr:latest
-    container_name: scriberr-sidecarr
-    env_file:
-      - .env
-    environment:
-      - PUID=${UID:-1024}
-      - PGID=${GID:-100}
+      - "8080:8080"
     volumes:
-      - ${DIR_DATA}/app_data/transcripts:/watch/transcripts:ro
-      - ${DIR_DATA}/sidecarr_data:/app/data
-    depends_on:
-      - scriberr
-    networks:
-      - services
+      - scriberr_data:/app/data
+      - env_data:/app/whisperx-env
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      # Security: already set in container, but can be overridden
+      - APP_ENV=production
+      # CORS: comma-separated list of allowed origins for production
+      # - ALLOWED_ORIGINS=https://your-domain.com
     restart: unless-stopped
 
-networks:
-  services:
-    external: true
+volumes:
+  scriberr_data: {}
+  env_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,44 @@
 services:
   scriberr:
-    image: ghcr.io/rishikanthc/scriberr:latest
-    ports:
-      - "8080:8080"
-    volumes:
-      - scriberr_data:/app/data
-      - env_data:/app/whisperx-env
+    build: .
+    container_name: scriberr
     environment:
-      - PUID=${PUID:-1000}
-      - PGID=${PGID:-1000}
-      # Security: already set in container, but can be overridden
-      - APP_ENV=production
-      # CORS: comma-separated list of allowed origins for production
-      # - ALLOWED_ORIGINS=https://your-domain.com
+      - PUID=${UID:-1024}
+      - PGID=${GID:-100}
+      - APP_ENV=${APP_ENV:-production}
+      - TZ=${TZ:-America/New_York}
+      # Set ALLOWED_ORIGINS to the HTTPS URL used for Scriberr if needed.
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
+      # Only set this to false when accessing Scriberr directly over plain HTTP.
+      - HF_TOKEN=${HF_TOKEN:-token_here}
+      - SECURE_COOKIES=${SECURE_COOKIES:-true}
+    volumes:
+      - ${DIR_RECORDINGS}:/voice_recordings
+      - ${DIR_DATA}/app_data:/app/data
+      - ${DIR_DATA}/whisperx-env:/app/whisperx-env
+    ports:
+      - ${PORT:-8080}:8080
+    networks:
+      - services
     restart: unless-stopped
 
-volumes:
-  scriberr_data: {}
-  env_data: {}
+  scriberr-sidecarr:
+    image: docker.io/jordanmarchetto/scriberr-sidecarr:latest
+    container_name: scriberr-sidecarr
+    env_file:
+      - .env
+    environment:
+      - PUID=${UID:-1024}
+      - PGID=${GID:-100}
+    volumes:
+      - ${DIR_DATA}/app_data/transcripts:/watch/transcripts:ro
+      - ${DIR_DATA}/sidecarr_data:/app/data
+    depends_on:
+      - scriberr
+    networks:
+      - services
+    restart: unless-stopped
+
+networks:
+  services:
+    external: true

--- a/internal/api/summary_handlers.go
+++ b/internal/api/summary_handlers.go
@@ -219,9 +219,15 @@ func (h *Handler) SaveSummarySettings(c *gin.Context) {
 			s = &models.SummarySetting{
 				UpdatedAt: time.Now(),
 			}
-			if req.DefaultModel != nil { s.DefaultModel = *req.DefaultModel }
-			if req.AutoSummarize != nil { s.AutoSummarize = *req.AutoSummarize }
-			if req.DefaultTemplateID != nil { s.DefaultTemplateID = req.DefaultTemplateID }
+			if req.DefaultModel != nil {
+				s.DefaultModel = *req.DefaultModel
+			}
+			if req.AutoSummarize != nil {
+				s.AutoSummarize = *req.AutoSummarize
+			}
+			if req.DefaultTemplateID != nil {
+				s.DefaultTemplateID = req.DefaultTemplateID
+			}
 			// We can't use Create from BaseRepository because it expects *T, but GetSettings returns *T.
 			// BaseRepository.Create expects *T.
 			// Actually BaseRepository[T] Create takes *T.
@@ -232,8 +238,14 @@ func (h *Handler) SaveSummarySettings(c *gin.Context) {
 			// I need to add SaveSettings to SummaryRepository which handles creation too.
 			// I added SaveSettings(ctx, settings).
 			if s.AutoSummarize {
-				if s.DefaultTemplateID == nil || *s.DefaultTemplateID == "" { c.JSON(http.StatusBadRequest, gin.H{"error": "a default summary template is required when auto-summarize is enabled"}); return }
-				if _, err := h.summaryRepo.FindByID(c.Request.Context(), *s.DefaultTemplateID); err != nil { c.JSON(http.StatusBadRequest, gin.H{"error": "default summary template not found"}); return }
+				if s.DefaultTemplateID == nil || *s.DefaultTemplateID == "" {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "a default summary template is required when auto-summarize is enabled"})
+					return
+				}
+				if _, err := h.summaryRepo.FindByID(c.Request.Context(), *s.DefaultTemplateID); err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "default summary template not found"})
+					return
+				}
 			}
 			if err := h.summaryRepo.SaveSettings(c.Request.Context(), s); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
@@ -245,12 +257,24 @@ func (h *Handler) SaveSummarySettings(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
 		return
 	}
-	if req.DefaultModel != nil { s.DefaultModel = *req.DefaultModel }
-	if req.AutoSummarize != nil { s.AutoSummarize = *req.AutoSummarize }
-	if req.DefaultTemplateID != nil { s.DefaultTemplateID = req.DefaultTemplateID }
+	if req.DefaultModel != nil {
+		s.DefaultModel = *req.DefaultModel
+	}
+	if req.AutoSummarize != nil {
+		s.AutoSummarize = *req.AutoSummarize
+	}
+	if req.DefaultTemplateID != nil {
+		s.DefaultTemplateID = req.DefaultTemplateID
+	}
 	if s.AutoSummarize {
-		if s.DefaultTemplateID == nil || *s.DefaultTemplateID == "" { c.JSON(http.StatusBadRequest, gin.H{"error": "a default summary template is required when auto-summarize is enabled"}); return }
-		if _, err := h.summaryRepo.FindByID(c.Request.Context(), *s.DefaultTemplateID); err != nil { c.JSON(http.StatusBadRequest, gin.H{"error": "default summary template not found"}); return }
+		if s.DefaultTemplateID == nil || *s.DefaultTemplateID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "a default summary template is required when auto-summarize is enabled"})
+			return
+		}
+		if _, err := h.summaryRepo.FindByID(c.Request.Context(), *s.DefaultTemplateID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "default summary template not found"})
+			return
+		}
 	}
 	s.UpdatedAt = time.Now()
 	if err := h.summaryRepo.SaveSettings(c.Request.Context(), s); err != nil {

--- a/internal/api/summary_handlers.go
+++ b/internal/api/summary_handlers.go
@@ -161,11 +161,22 @@ func (h *Handler) UpdateSummaryTemplate(c *gin.Context) {
 // @Produce json
 // @Param id path string true "Template ID"
 // @Success 204 {string} string "No Content"
+// @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Security ApiKeyAuth
 // @Router /api/v1/summaries/{id} [delete]
 func (h *Handler) DeleteSummaryTemplate(c *gin.Context) {
 	id := c.Param("id")
+	settings, err := h.summaryRepo.GetSettings(c.Request.Context())
+	if err != nil && err != gorm.ErrRecordNotFound {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch summary settings"})
+		return
+	}
+	if settings != nil && settings.DefaultTemplateID != nil && *settings.DefaultTemplateID == id {
+		c.JSON(http.StatusConflict, gin.H{"error": "Choose or clear the default summary template before deleting it"})
+		return
+	}
+
 	if err := h.summaryRepo.Delete(c.Request.Context(), id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete template"})
 		return
@@ -228,15 +239,6 @@ func (h *Handler) SaveSummarySettings(c *gin.Context) {
 			if req.DefaultTemplateID != nil {
 				s.DefaultTemplateID = req.DefaultTemplateID
 			}
-			// We can't use Create from BaseRepository because it expects *T, but GetSettings returns *T.
-			// BaseRepository.Create expects *T.
-			// Actually BaseRepository[T] Create takes *T.
-			// But here T is models.SummaryTemplate, NOT models.SummarySetting.
-			// SummaryRepository handles SummaryTemplate.
-			// But GetSettings returns SummarySetting.
-			// So I can't use h.summaryRepo.Create(s) because s is SummarySetting, not SummaryTemplate.
-			// I need to add SaveSettings to SummaryRepository which handles creation too.
-			// I added SaveSettings(ctx, settings).
 			if s.AutoSummarize {
 				if s.DefaultTemplateID == nil || *s.DefaultTemplateID == "" {
 					c.JSON(http.StatusBadRequest, gin.H{"error": "a default summary template is required when auto-summarize is enabled"})

--- a/internal/api/summary_handlers.go
+++ b/internal/api/summary_handlers.go
@@ -19,11 +19,15 @@ type SummaryTemplateRequest struct {
 }
 
 type SummarySettingsRequest struct {
-	DefaultModel string `json:"default_model" binding:"required,min=1"`
+	DefaultModel      *string `json:"default_model,omitempty"`
+	AutoSummarize     *bool   `json:"auto_summarize,omitempty"`
+	DefaultTemplateID *string `json:"default_template_id,omitempty"`
 }
 
 type SummarySettingsResponse struct {
-	DefaultModel string `json:"default_model"`
+	DefaultModel      string  `json:"default_model"`
+	AutoSummarize     bool    `json:"auto_summarize"`
+	DefaultTemplateID *string `json:"default_template_id,omitempty"`
 }
 
 // ListSummaryTemplates returns all templates
@@ -182,13 +186,13 @@ func (h *Handler) GetSummarySettings(c *gin.Context) {
 	s, err := h.summaryRepo.GetSettings(c.Request.Context())
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: ""})
+			c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: "", AutoSummarize: false})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch settings"})
 		return
 	}
-	c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: s.DefaultModel})
+	c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: s.DefaultModel, AutoSummarize: s.AutoSummarize, DefaultTemplateID: s.DefaultTemplateID})
 }
 
 // SaveSummarySettings updates default model (creates row if absent)
@@ -213,9 +217,11 @@ func (h *Handler) SaveSummarySettings(c *gin.Context) {
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			s = &models.SummarySetting{
-				DefaultModel: req.DefaultModel,
-				UpdatedAt:    time.Now(),
+				UpdatedAt: time.Now(),
 			}
+			if req.DefaultModel != nil { s.DefaultModel = *req.DefaultModel }
+			if req.AutoSummarize != nil { s.AutoSummarize = *req.AutoSummarize }
+			if req.DefaultTemplateID != nil { s.DefaultTemplateID = req.DefaultTemplateID }
 			// We can't use Create from BaseRepository because it expects *T, but GetSettings returns *T.
 			// BaseRepository.Create expects *T.
 			// Actually BaseRepository[T] Create takes *T.
@@ -225,21 +231,31 @@ func (h *Handler) SaveSummarySettings(c *gin.Context) {
 			// So I can't use h.summaryRepo.Create(s) because s is SummarySetting, not SummaryTemplate.
 			// I need to add SaveSettings to SummaryRepository which handles creation too.
 			// I added SaveSettings(ctx, settings).
+			if s.AutoSummarize {
+				if s.DefaultTemplateID == nil || *s.DefaultTemplateID == "" { c.JSON(http.StatusBadRequest, gin.H{"error": "a default summary template is required when auto-summarize is enabled"}); return }
+				if _, err := h.summaryRepo.FindByID(c.Request.Context(), *s.DefaultTemplateID); err != nil { c.JSON(http.StatusBadRequest, gin.H{"error": "default summary template not found"}); return }
+			}
 			if err := h.summaryRepo.SaveSettings(c.Request.Context(), s); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
 				return
 			}
-			c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: s.DefaultModel})
+			c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: s.DefaultModel, AutoSummarize: s.AutoSummarize, DefaultTemplateID: s.DefaultTemplateID})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
 		return
 	}
-	s.DefaultModel = req.DefaultModel
+	if req.DefaultModel != nil { s.DefaultModel = *req.DefaultModel }
+	if req.AutoSummarize != nil { s.AutoSummarize = *req.AutoSummarize }
+	if req.DefaultTemplateID != nil { s.DefaultTemplateID = req.DefaultTemplateID }
+	if s.AutoSummarize {
+		if s.DefaultTemplateID == nil || *s.DefaultTemplateID == "" { c.JSON(http.StatusBadRequest, gin.H{"error": "a default summary template is required when auto-summarize is enabled"}); return }
+		if _, err := h.summaryRepo.FindByID(c.Request.Context(), *s.DefaultTemplateID); err != nil { c.JSON(http.StatusBadRequest, gin.H{"error": "default summary template not found"}); return }
+	}
 	s.UpdatedAt = time.Now()
 	if err := h.summaryRepo.SaveSettings(c.Request.Context(), s); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
 		return
 	}
-	c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: s.DefaultModel})
+	c.JSON(http.StatusOK, SummarySettingsResponse{DefaultModel: s.DefaultModel, AutoSummarize: s.AutoSummarize, DefaultTemplateID: s.DefaultTemplateID})
 }

--- a/internal/autosummary/service.go
+++ b/internal/autosummary/service.go
@@ -1,64 +1,158 @@
 package autosummary
 
 import (
-    "context"
-    "fmt"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
-    "scriberr/internal/llm"
-    "scriberr/internal/models"
-    "scriberr/internal/repository"
-    "scriberr/pkg/logger"
-    "gorm.io/gorm"
+	"scriberr/internal/llm"
+	"scriberr/internal/models"
+	"scriberr/internal/repository"
+	transcriptioninterfaces "scriberr/internal/transcription/interfaces"
+	"scriberr/pkg/logger"
+
+	"gorm.io/gorm"
 )
 
 // Service generates summaries for completed transcriptions when enabled.
 type Service struct {
-    jobRepo repository.JobRepository
-    summaryRepo repository.SummaryRepository
-    llmRepo repository.LLMConfigRepository
+	jobRepo            repository.JobRepository
+	summaryRepo        repository.SummaryRepository
+	llmRepo            repository.LLMConfigRepository
+	speakerMappingRepo repository.SpeakerMappingRepository
 }
 
-func NewService(jobRepo repository.JobRepository, summaryRepo repository.SummaryRepository, llmRepo repository.LLMConfigRepository) *Service {
-    return &Service{jobRepo: jobRepo, summaryRepo: summaryRepo, llmRepo: llmRepo}
+func NewService(
+	jobRepo repository.JobRepository,
+	summaryRepo repository.SummaryRepository,
+	llmRepo repository.LLMConfigRepository,
+	speakerMappingRepo repository.SpeakerMappingRepository,
+) *Service {
+	return &Service{
+		jobRepo:            jobRepo,
+		summaryRepo:        summaryRepo,
+		llmRepo:            llmRepo,
+		speakerMappingRepo: speakerMappingRepo,
+	}
 }
 
 func (s *Service) Process(ctx context.Context, jobID string) error {
-    settings, err := s.summaryRepo.GetSettings(ctx)
-    if err != nil { if err == gorm.ErrRecordNotFound { return nil }; return fmt.Errorf("load summary settings: %w", err) }
-    if !settings.AutoSummarize || settings.DefaultTemplateID == nil || *settings.DefaultTemplateID == "" { return nil }
+	settings, err := s.summaryRepo.GetSettings(ctx)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil
+		}
+		return fmt.Errorf("load summary settings: %w", err)
+	}
+	if !settings.AutoSummarize || settings.DefaultTemplateID == nil || *settings.DefaultTemplateID == "" {
+		return nil
+	}
 
-    job, err := s.jobRepo.FindWithAssociations(ctx, jobID)
-    if err != nil { return fmt.Errorf("load transcription: %w", err) }
-    if job.Transcript == nil || strings.TrimSpace(*job.Transcript) == "" { return fmt.Errorf("transcription has no transcript") }
-    template, err := s.summaryRepo.FindByID(ctx, *settings.DefaultTemplateID)
-    if err != nil { return fmt.Errorf("load default summary template: %w", err) }
-    cfg, err := s.llmRepo.GetActive(ctx)
-    if err != nil { return fmt.Errorf("load active LLM configuration: %w", err) }
+	job, err := s.jobRepo.FindWithAssociations(ctx, jobID)
+	if err != nil {
+		return fmt.Errorf("load transcription: %w", err)
+	}
+	if job.Transcript == nil || strings.TrimSpace(*job.Transcript) == "" {
+		return fmt.Errorf("transcription has no transcript")
+	}
+	template, err := s.summaryRepo.FindByID(ctx, *settings.DefaultTemplateID)
+	if err != nil {
+		return fmt.Errorf("load default summary template: %w", err)
+	}
 
-    var service llm.Service
-    switch strings.ToLower(cfg.Provider) {
-    case "openai":
-        if cfg.APIKey == nil || *cfg.APIKey == "" { return fmt.Errorf("OpenAI API key is not configured") }
-        service = llm.NewOpenAIService(*cfg.APIKey, cfg.OpenAIBaseURL)
-    case "ollama":
-        if cfg.BaseURL == nil || *cfg.BaseURL == "" { return fmt.Errorf("Ollama base URL is not configured") }
-        service = llm.NewOllamaService(*cfg.BaseURL)
-    default:
-        return fmt.Errorf("unsupported LLM provider: %s", cfg.Provider)
-    }
+	var speakerMappings []models.SpeakerMapping
+	if template.IncludeSpeakerInfo {
+		speakerMappings, err = s.speakerMappingRepo.ListByJob(ctx, jobID)
+		if err != nil {
+			return fmt.Errorf("load speaker mappings: %w", err)
+		}
+	}
+	content, err := buildSummaryContent(*job.Transcript, template.Prompt, template.IncludeSpeakerInfo, speakerMappings)
+	if err != nil {
+		return err
+	}
 
-    requestCtx, cancel := context.WithTimeout(ctx, 60*time.Minute)
-    defer cancel()
-    content := "Transcript:\n" + *job.Transcript + "\n\nInstructions:\n" + template.Prompt
-    response, err := service.ChatCompletion(requestCtx, template.Model, []llm.ChatMessage{{Role: "user", Content: content}}, 0.0)
-    if err != nil { return fmt.Errorf("generate summary: %w", err) }
-    if response == nil || len(response.Choices) == 0 || strings.TrimSpace(response.Choices[0].Message.Content) == "" { return fmt.Errorf("LLM returned an empty summary") }
+	cfg, err := s.llmRepo.GetActive(ctx)
+	if err != nil {
+		return fmt.Errorf("load active LLM configuration: %w", err)
+	}
 
-    summary := &models.Summary{TranscriptionID: job.ID, TemplateID: &template.ID, Model: template.Model, Content: response.Choices[0].Message.Content}
-    if err := s.summaryRepo.SaveSummary(ctx, summary); err != nil { return fmt.Errorf("save summary: %w", err) }
-    if err := s.jobRepo.UpdateSummary(ctx, job.ID, summary.Content); err != nil { logger.Warn("Auto-summary saved but job cache update failed", "job_id", job.ID, "error", err) }
-    logger.Info("Automatic summary generated", "job_id", job.ID, "template_id", template.ID)
-    return nil
+	var service llm.Service
+	switch strings.ToLower(cfg.Provider) {
+	case "openai":
+		if cfg.APIKey == nil || *cfg.APIKey == "" {
+			return fmt.Errorf("OpenAI API key is not configured")
+		}
+		service = llm.NewOpenAIService(*cfg.APIKey, cfg.OpenAIBaseURL)
+	case "ollama":
+		if cfg.BaseURL == nil || *cfg.BaseURL == "" {
+			return fmt.Errorf("Ollama base URL is not configured")
+		}
+		service = llm.NewOllamaService(*cfg.BaseURL)
+	default:
+		return fmt.Errorf("unsupported LLM provider: %s", cfg.Provider)
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, 60*time.Minute)
+	defer cancel()
+	response, err := service.ChatCompletion(requestCtx, template.Model, []llm.ChatMessage{{Role: "user", Content: content}}, 0.0)
+	if err != nil {
+		return fmt.Errorf("generate summary: %w", err)
+	}
+	if response == nil || len(response.Choices) == 0 || strings.TrimSpace(response.Choices[0].Message.Content) == "" {
+		return fmt.Errorf("LLM returned an empty summary")
+	}
+
+	summary := &models.Summary{TranscriptionID: job.ID, TemplateID: &template.ID, Model: template.Model, Content: response.Choices[0].Message.Content}
+	if err := s.summaryRepo.SaveSummary(ctx, summary); err != nil {
+		return fmt.Errorf("save summary: %w", err)
+	}
+	if err := s.jobRepo.UpdateSummary(ctx, job.ID, summary.Content); err != nil {
+		logger.Warn("Auto-summary saved but job cache update failed", "job_id", job.ID, "error", err)
+	}
+	logger.Info("Automatic summary generated", "job_id", job.ID, "template_id", template.ID)
+	return nil
+}
+
+func buildSummaryContent(
+	transcriptJSON string,
+	prompt string,
+	includeSpeakerInfo bool,
+	speakerMappings []models.SpeakerMapping,
+) (string, error) {
+	var transcript transcriptioninterfaces.TranscriptResult
+	if err := json.Unmarshal([]byte(transcriptJSON), &transcript); err != nil {
+		return "", fmt.Errorf("parse transcript: %w", err)
+	}
+
+	transcriptText := transcript.Text
+	transcriptLabel := "Transcript:"
+	if includeSpeakerInfo && len(transcript.Segments) > 0 {
+		transcriptLabel = "Transcript (with speaker labels - each line is prefixed with [SPEAKER_NAME]):"
+		mappingNames := make(map[string]string, len(speakerMappings))
+		for _, mapping := range speakerMappings {
+			mappingNames[mapping.OriginalSpeaker] = mapping.CustomName
+		}
+
+		lines := make([]string, 0, len(transcript.Segments))
+		for _, segment := range transcript.Segments {
+			speaker := "UNKNOWN"
+			if segment.Speaker != nil && *segment.Speaker != "" {
+				speaker = *segment.Speaker
+				if customName, ok := mappingNames[speaker]; ok {
+					speaker = customName
+				}
+			}
+			lines = append(lines, fmt.Sprintf("[%s] %s", speaker, strings.TrimSpace(segment.Text)))
+		}
+		transcriptText = strings.Join(lines, "\n")
+	}
+
+	if strings.TrimSpace(transcriptText) == "" {
+		return "", fmt.Errorf("transcription has no transcript text")
+	}
+
+	return transcriptLabel + "\n" + transcriptText + "\n\nInstructions:\n" + prompt, nil
 }

--- a/internal/autosummary/service.go
+++ b/internal/autosummary/service.go
@@ -1,0 +1,64 @@
+package autosummary
+
+import (
+    "context"
+    "fmt"
+    "strings"
+    "time"
+
+    "scriberr/internal/llm"
+    "scriberr/internal/models"
+    "scriberr/internal/repository"
+    "scriberr/pkg/logger"
+    "gorm.io/gorm"
+)
+
+// Service generates summaries for completed transcriptions when enabled.
+type Service struct {
+    jobRepo repository.JobRepository
+    summaryRepo repository.SummaryRepository
+    llmRepo repository.LLMConfigRepository
+}
+
+func NewService(jobRepo repository.JobRepository, summaryRepo repository.SummaryRepository, llmRepo repository.LLMConfigRepository) *Service {
+    return &Service{jobRepo: jobRepo, summaryRepo: summaryRepo, llmRepo: llmRepo}
+}
+
+func (s *Service) Process(ctx context.Context, jobID string) error {
+    settings, err := s.summaryRepo.GetSettings(ctx)
+    if err != nil { if err == gorm.ErrRecordNotFound { return nil }; return fmt.Errorf("load summary settings: %w", err) }
+    if !settings.AutoSummarize || settings.DefaultTemplateID == nil || *settings.DefaultTemplateID == "" { return nil }
+
+    job, err := s.jobRepo.FindWithAssociations(ctx, jobID)
+    if err != nil { return fmt.Errorf("load transcription: %w", err) }
+    if job.Transcript == nil || strings.TrimSpace(*job.Transcript) == "" { return fmt.Errorf("transcription has no transcript") }
+    template, err := s.summaryRepo.FindByID(ctx, *settings.DefaultTemplateID)
+    if err != nil { return fmt.Errorf("load default summary template: %w", err) }
+    cfg, err := s.llmRepo.GetActive(ctx)
+    if err != nil { return fmt.Errorf("load active LLM configuration: %w", err) }
+
+    var service llm.Service
+    switch strings.ToLower(cfg.Provider) {
+    case "openai":
+        if cfg.APIKey == nil || *cfg.APIKey == "" { return fmt.Errorf("OpenAI API key is not configured") }
+        service = llm.NewOpenAIService(*cfg.APIKey, cfg.OpenAIBaseURL)
+    case "ollama":
+        if cfg.BaseURL == nil || *cfg.BaseURL == "" { return fmt.Errorf("Ollama base URL is not configured") }
+        service = llm.NewOllamaService(*cfg.BaseURL)
+    default:
+        return fmt.Errorf("unsupported LLM provider: %s", cfg.Provider)
+    }
+
+    requestCtx, cancel := context.WithTimeout(ctx, 60*time.Minute)
+    defer cancel()
+    content := "Transcript:\n" + *job.Transcript + "\n\nInstructions:\n" + template.Prompt
+    response, err := service.ChatCompletion(requestCtx, template.Model, []llm.ChatMessage{{Role: "user", Content: content}}, 0.0)
+    if err != nil { return fmt.Errorf("generate summary: %w", err) }
+    if response == nil || len(response.Choices) == 0 || strings.TrimSpace(response.Choices[0].Message.Content) == "" { return fmt.Errorf("LLM returned an empty summary") }
+
+    summary := &models.Summary{TranscriptionID: job.ID, TemplateID: &template.ID, Model: template.Model, Content: response.Choices[0].Message.Content}
+    if err := s.summaryRepo.SaveSummary(ctx, summary); err != nil { return fmt.Errorf("save summary: %w", err) }
+    if err := s.jobRepo.UpdateSummary(ctx, job.ID, summary.Content); err != nil { logger.Warn("Auto-summary saved but job cache update failed", "job_id", job.ID, "error", err) }
+    logger.Info("Automatic summary generated", "job_id", job.ID, "template_id", template.ID)
+    return nil
+}

--- a/internal/autosummary/service_test.go
+++ b/internal/autosummary/service_test.go
@@ -1,0 +1,67 @@
+package autosummary
+
+import (
+	"encoding/json"
+	"testing"
+
+	"scriberr/internal/models"
+	transcriptioninterfaces "scriberr/internal/transcription/interfaces"
+)
+
+func TestBuildSummaryContentUsesPlainTranscriptText(t *testing.T) {
+	transcriptJSON := marshalTranscript(t, transcriptioninterfaces.TranscriptResult{
+		Text: "Hello from the transcript.",
+	})
+
+	content, err := buildSummaryContent(transcriptJSON, "Summarize this.", false, nil)
+	if err != nil {
+		t.Fatalf("buildSummaryContent returned an error: %v", err)
+	}
+
+	want := "Transcript:\nHello from the transcript.\n\nInstructions:\nSummarize this."
+	if content != want {
+		t.Fatalf("buildSummaryContent() = %q, want %q", content, want)
+	}
+}
+
+func TestBuildSummaryContentUsesSpeakerLabelsAndMappings(t *testing.T) {
+	speakerOne := "SPEAKER_00"
+	speakerTwo := "SPEAKER_01"
+	transcriptJSON := marshalTranscript(t, transcriptioninterfaces.TranscriptResult{
+		Text: "Hello. Hi.",
+		Segments: []transcriptioninterfaces.TranscriptSegment{
+			{Text: " Hello. ", Speaker: &speakerOne},
+			{Text: "Hi.", Speaker: &speakerTwo},
+		},
+	})
+	mappings := []models.SpeakerMapping{
+		{OriginalSpeaker: speakerOne, CustomName: "Jordan"},
+	}
+
+	content, err := buildSummaryContent(transcriptJSON, "Summarize this.", true, mappings)
+	if err != nil {
+		t.Fatalf("buildSummaryContent returned an error: %v", err)
+	}
+
+	want := "Transcript (with speaker labels - each line is prefixed with [SPEAKER_NAME]):\n" +
+		"[Jordan] Hello.\n[SPEAKER_01] Hi.\n\nInstructions:\nSummarize this."
+	if content != want {
+		t.Fatalf("buildSummaryContent() = %q, want %q", content, want)
+	}
+}
+
+func TestBuildSummaryContentRejectsInvalidTranscriptJSON(t *testing.T) {
+	if _, err := buildSummaryContent("not JSON", "Summarize this.", false, nil); err == nil {
+		t.Fatal("buildSummaryContent returned no error for invalid transcript JSON")
+	}
+}
+
+func marshalTranscript(t *testing.T, transcript transcriptioninterfaces.TranscriptResult) string {
+	t.Helper()
+
+	data, err := json.Marshal(transcript)
+	if err != nil {
+		t.Fatalf("marshal transcript: %v", err)
+	}
+	return string(data)
+}

--- a/internal/autosummary/service_test.go
+++ b/internal/autosummary/service_test.go
@@ -1,12 +1,51 @@
 package autosummary
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	"scriberr/internal/models"
+	"scriberr/internal/repository"
 	transcriptioninterfaces "scriberr/internal/transcription/interfaces"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
 )
+
+func newAutoSummaryTestService(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	dsn := fmt.Sprintf("file:auto-summary-test-%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&models.SummarySetting{}, &models.SummaryTemplate{}); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	return &Service{summaryRepo: repository.NewSummaryRepository(db)}, db
+}
+
+func TestProcessDoesNothingWithoutSettings(t *testing.T) {
+	service, _ := newAutoSummaryTestService(t)
+
+	if err := service.Process(context.Background(), "job-123"); err != nil {
+		t.Fatalf("Process returned an error: %v", err)
+	}
+}
+
+func TestProcessDoesNothingWhenDisabled(t *testing.T) {
+	service, db := newAutoSummaryTestService(t)
+	if err := db.Create(&models.SummarySetting{AutoSummarize: false}).Error; err != nil {
+		t.Fatalf("create summary settings: %v", err)
+	}
+
+	if err := service.Process(context.Background(), "job-123"); err != nil {
+		t.Fatalf("Process returned an error: %v", err)
+	}
+}
 
 func TestBuildSummaryContentUsesPlainTranscriptText(t *testing.T) {
 	transcriptJSON := marshalTranscript(t, transcriptioninterfaces.TranscriptResult{

--- a/internal/models/summary.go
+++ b/internal/models/summary.go
@@ -28,9 +28,11 @@ func (st *SummaryTemplate) BeforeCreate(tx *gorm.DB) error {
 
 // SummarySetting stores global settings for summarization (single row)
 type SummarySetting struct {
-	ID           uint      `json:"id" gorm:"primaryKey"`
-	DefaultModel string    `json:"default_model" gorm:"type:varchar(255);not null;default:''"`
-	UpdatedAt    time.Time `json:"updated_at" gorm:"autoUpdateTime"`
+	ID                uint      `json:"id" gorm:"primaryKey"`
+	DefaultModel      string    `json:"default_model" gorm:"type:varchar(255);not null;default:''"`
+	AutoSummarize     bool      `json:"auto_summarize" gorm:"not null;default:false"`
+	DefaultTemplateID *string   `json:"default_template_id,omitempty" gorm:"type:varchar(36)"`
+	UpdatedAt         time.Time `json:"updated_at" gorm:"autoUpdateTime"`
 }
 
 // Summary stores a generated summary linked to a transcription

--- a/internal/transcription/unified_service.go
+++ b/internal/transcription/unified_service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"scriberr/internal/autosummary"
 	"scriberr/internal/models"
 	"scriberr/internal/repository"
 	"scriberr/internal/sse"
@@ -52,6 +53,7 @@ type UnifiedTranscriptionService struct {
 	jobRepo               repository.JobRepository
 	webhookService        *webhook.Service
 	broadcaster           *sse.Broadcaster
+	autoSummaryService    *autosummary.Service
 }
 
 // NewUnifiedTranscriptionService creates a new unified transcription service
@@ -76,6 +78,9 @@ func NewUnifiedTranscriptionService(jobRepo repository.JobRepository, tempDir, o
 func (u *UnifiedTranscriptionService) SetBroadcaster(b *sse.Broadcaster) {
 	u.broadcaster = b
 }
+
+// SetAutoSummaryService configures background summaries after successful transcription.
+func (u *UnifiedTranscriptionService) SetAutoSummaryService(service *autosummary.Service) { u.autoSummaryService = service }
 
 // Initialize prepares all registered models for use
 func (u *UnifiedTranscriptionService) Initialize(ctx context.Context) error {
@@ -203,6 +208,11 @@ func (u *UnifiedTranscriptionService) ProcessJob(ctx context.Context, jobID stri
 
 	// Success
 	updateExecutionStatus(models.StatusCompleted, "")
+	if u.autoSummaryService != nil {
+		go func() {
+			if err := u.autoSummaryService.Process(context.Background(), jobID); err != nil { logger.Warn("Automatic summary failed", "job_id", jobID, "error", err) }
+		}()
+	}
 	logger.Info("Job processed successfully", "job_id", jobID, "duration", time.Since(startTime))
 	return nil
 }

--- a/internal/transcription/unified_service.go
+++ b/internal/transcription/unified_service.go
@@ -80,7 +80,9 @@ func (u *UnifiedTranscriptionService) SetBroadcaster(b *sse.Broadcaster) {
 }
 
 // SetAutoSummaryService configures background summaries after successful transcription.
-func (u *UnifiedTranscriptionService) SetAutoSummaryService(service *autosummary.Service) { u.autoSummaryService = service }
+func (u *UnifiedTranscriptionService) SetAutoSummaryService(service *autosummary.Service) {
+	u.autoSummaryService = service
+}
 
 // Initialize prepares all registered models for use
 func (u *UnifiedTranscriptionService) Initialize(ctx context.Context) error {
@@ -210,7 +212,9 @@ func (u *UnifiedTranscriptionService) ProcessJob(ctx context.Context, jobID stri
 	updateExecutionStatus(models.StatusCompleted, "")
 	if u.autoSummaryService != nil {
 		go func() {
-			if err := u.autoSummaryService.Process(context.Background(), jobID); err != nil { logger.Warn("Automatic summary failed", "job_id", jobID, "error", err) }
+			if err := u.autoSummaryService.Process(context.Background(), jobID); err != nil {
+				logger.Warn("Automatic summary failed", "job_id", jobID, "error", err)
+			}
 		}()
 	}
 	logger.Info("Job processed successfully", "job_id", jobID, "duration", time.Since(startTime))

--- a/web/frontend/src/features/settings/components/AutoSummarySettings.tsx
+++ b/web/frontend/src/features/settings/components/AutoSummarySettings.tsx
@@ -32,7 +32,10 @@ export function AutoSummarySettings() {
 
   const save = async () => {
     setMessage("");
-    if (enabled && !templateID) { setMessage("Choose a default template before enabling auto-summary."); return; }
+    if (enabled && !templateID) {
+      setMessage("Choose a default template before enabling auto-summary.");
+      return;
+    }
     setSaving(true);
     try {
       const response = await fetch("/api/v1/summaries/settings", {
@@ -40,14 +43,17 @@ export function AutoSummarySettings() {
         headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ auto_summarize: enabled, default_template_id: templateID || null }),
       });
-      if (!response.ok) { setMessage((await response.json()).error || "Failed to save auto-summary settings."); return; }
+      if (!response.ok) {
+        setMessage((await response.json()).error || "Failed to save auto-summary settings.");
+        return;
+      }
       setMessage("Auto-summary settings saved.");
     } finally { setSaving(false); }
   };
 
-  return <div className="bg-[var(--bg-main)] border border-[var(--border-subtle)] rounded-xl p-4 sm:p-5">
+  return <div className="bg-[var(--bg-main)]/50 border border-[var(--border-subtle)] rounded-[var(--radius-card)] p-4 sm:p-6 shadow-sm">
     <div className="flex items-start justify-between gap-4">
-      <div><h3 className="font-medium text-[var(--text-primary)]">Automatic summaries</h3><p className="text-sm text-[var(--text-secondary)] mt-1">Generate a summary in the background when a transcription finishes successfully.</p></div>
+      <div><h3 className="text-lg font-medium text-[var(--text-primary)]">Auto-Summary</h3><p className="text-sm text-[var(--text-secondary)] mt-1">Generate a summary in the background when a transcription finishes successfully.</p></div>
       <Switch checked={enabled} onCheckedChange={setEnabled} aria-label="Enable automatic summaries" />
     </div>
     <div className="mt-4 max-w-xl">

--- a/web/frontend/src/features/settings/components/AutoSummarySettings.tsx
+++ b/web/frontend/src/features/settings/components/AutoSummarySettings.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { useAuth } from "@/features/auth/hooks/useAuth";
+
+type Template = { id: string; name: string; model: string };
+type Settings = { auto_summarize: boolean; default_template_id?: string; default_model?: string };
+
+export function AutoSummarySettings() {
+  const { getAuthHeaders } = useAuth();
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [enabled, setEnabled] = useState(false);
+  const [templateID, setTemplateID] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      const headers = { ...getAuthHeaders() };
+      const [settingsResponse, templatesResponse] = await Promise.all([
+        fetch("/api/v1/summaries/settings", { headers }),
+        fetch("/api/v1/summaries", { headers }),
+      ]);
+      if (settingsResponse.ok) {
+        const settings: Settings = await settingsResponse.json();
+        setEnabled(settings.auto_summarize);
+        setTemplateID(settings.default_template_id || "");
+      }
+      if (templatesResponse.ok) setTemplates(await templatesResponse.json());
+    })();
+  }, [getAuthHeaders]);
+
+  const save = async () => {
+    setMessage("");
+    if (enabled && !templateID) { setMessage("Choose a default template before enabling auto-summary."); return; }
+    setSaving(true);
+    try {
+      const response = await fetch("/api/v1/summaries/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+        body: JSON.stringify({ auto_summarize: enabled, default_template_id: templateID || null }),
+      });
+      if (!response.ok) { setMessage((await response.json()).error || "Failed to save auto-summary settings."); return; }
+      setMessage("Auto-summary settings saved.");
+    } finally { setSaving(false); }
+  };
+
+  return <div className="bg-[var(--bg-main)] border border-[var(--border-subtle)] rounded-xl p-4 sm:p-5">
+    <div className="flex items-start justify-between gap-4">
+      <div><h3 className="font-medium text-[var(--text-primary)]">Automatic summaries</h3><p className="text-sm text-[var(--text-secondary)] mt-1">Generate a summary in the background when a transcription finishes successfully.</p></div>
+      <Switch checked={enabled} onCheckedChange={setEnabled} aria-label="Enable automatic summaries" />
+    </div>
+    <div className="mt-4 max-w-xl">
+      <label htmlFor="auto-summary-template" className="block text-sm font-medium text-[var(--text-primary)] mb-2">Default summary template</label>
+      <select id="auto-summary-template" value={templateID} onChange={(e) => setTemplateID(e.target.value)} className="flex h-9 w-full rounded-[var(--radius-btn)] border border-[var(--border-subtle)] bg-[var(--bg-card)] px-3 py-1 text-sm text-[var(--text-primary)]" disabled={templates.length === 0}>
+        <option value="">Select a template</option>{templates.map((template) => <option key={template.id} value={template.id}>{template.name} ({template.model})</option>)}
+      </select>
+      {templates.length === 0 && <p className="text-xs text-[var(--text-tertiary)] mt-2">Create a summary template below first.</p>}
+    </div>
+    <div className="flex items-center gap-3 mt-4"><Button onClick={save} disabled={saving}>{saving ? "Saving..." : "Save settings"}</Button>{message && <span className="text-sm text-[var(--text-secondary)]">{message}</span>}</div>
+  </div>;
+}

--- a/web/frontend/src/features/settings/components/AutoSummarySettings.tsx
+++ b/web/frontend/src/features/settings/components/AutoSummarySettings.tsx
@@ -41,13 +41,15 @@ export function AutoSummarySettings() {
       const response = await fetch("/api/v1/summaries/settings", {
         method: "POST",
         headers: { "Content-Type": "application/json", ...getAuthHeaders() },
-        body: JSON.stringify({ auto_summarize: enabled, default_template_id: templateID || null }),
+        body: JSON.stringify({ auto_summarize: enabled, default_template_id: templateID }),
       });
       if (!response.ok) {
         setMessage((await response.json()).error || "Failed to save auto-summary settings.");
         return;
       }
       setMessage("Auto-summary settings saved.");
+    } catch {
+      setMessage("Failed to save auto-summary settings.");
     } finally { setSaving(false); }
   };
 

--- a/web/frontend/src/features/settings/components/SummaryTemplatesTable.tsx
+++ b/web/frontend/src/features/settings/components/SummaryTemplatesTable.tsx
@@ -42,7 +42,8 @@ export function SummaryTemplatesTable({ onEdit, refreshTrigger = 0, disabled = f
       if (res.ok) {
         setItems(prev => prev.filter(i => i.id !== id));
       } else {
-        alert('Failed to delete');
+        const body: { error?: string } = await res.json().catch(() => ({}));
+        alert(body.error || 'Failed to delete');
       }
     } finally {
       setDeleting(prev => { const s = new Set(prev); s.delete(id); return s; });

--- a/web/frontend/src/features/settings/pages/SettingsPage.tsx
+++ b/web/frontend/src/features/settings/pages/SettingsPage.tsx
@@ -17,6 +17,7 @@ import { LLMSettings } from "../components/LLMSettings";
 import { SummaryTemplateDialog, type SummaryTemplate } from "../components/SummaryTemplateDialog";
 import { SummaryTemplatesTable } from "../components/SummaryTemplatesTable";
 import { CLISettingsTab } from "../components/CLISettingsTab";
+import { AutoSummarySettings } from "../components/AutoSummarySettings";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 
 export function Settings() {
@@ -162,6 +163,7 @@ export function Settings() {
                   Configure an LLM provider in the LLMs tab to enable summary templates and model selection.
                 </div>
               )}
+              <AutoSummarySettings />
               <SummaryTemplatesTable onEdit={(tpl) => { setEditingSummary(tpl); setSummaryDialogOpen(true); }} refreshTrigger={summaryRefresh} disabled={!llmConfigured} />
             </div>
 

--- a/web/frontend/src/features/settings/pages/SettingsPage.tsx
+++ b/web/frontend/src/features/settings/pages/SettingsPage.tsx
@@ -142,6 +142,8 @@ export function Settings() {
 
           {/* Summary Tab */}
           <TabsContent value="summary" className="space-y-6">
+            <AutoSummarySettings />
+
             <div className="bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-[var(--radius-card)] p-4 sm:p-6 shadow-sm">
               <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-0 mb-4">
                 <div>
@@ -163,7 +165,6 @@ export function Settings() {
                   Configure an LLM provider in the LLMs tab to enable summary templates and model selection.
                 </div>
               )}
-              <AutoSummarySettings />
               <SummaryTemplatesTable onEdit={(tpl) => { setEditingSummary(tpl); setSummaryDialogOpen(true); }} refreshTrigger={summaryRefresh} disabled={!llmConfigured} />
             </div>
 

--- a/web/project-site/public/api/swagger.json
+++ b/web/project-site/public/api/swagger.json
@@ -1944,6 +1944,15 @@
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4328,20 +4337,28 @@
         },
         "api.SummarySettingsRequest": {
             "type": "object",
-            "required": [
-                "default_model"
-            ],
             "properties": {
+                "auto_summarize": {
+                    "type": "boolean"
+                },
                 "default_model": {
-                    "type": "string",
-                    "minLength": 1
+                    "type": "string"
+                },
+                "default_template_id": {
+                    "type": "string"
                 }
             }
         },
         "api.SummarySettingsResponse": {
             "type": "object",
             "properties": {
+                "auto_summarize": {
+                    "type": "boolean"
+                },
                 "default_model": {
+                    "type": "string"
+                },
+                "default_template_id": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## Summary
- add persisted auto-summary setting and default template selection
- expose auto-summary state through the existing summary settings API
- generate summaries asynchronously after successful transcription
- add Settings UI controls for enabling the feature and choosing the template

## Validation
- `go test -count=1 ./...`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `git diff --check`

## Integration follow-up

PR #1 adds `summary.completed` and `summary.failed` webhook events. After that webhook work is merged into this branch, automatic summaries must emit the same lifecycle events for success and failure. This cross-PR wiring is intentionally called out here so it is not missed during integration.

## Screenshot

<img width="888" height="425" alt="image" src="https://github.com/user-attachments/assets/a44ad716-1282-4cb8-a5c8-e3f342f2c18a" />